### PR TITLE
Include puzzle size in analytics event names

### DIFF
--- a/web/src/components/App.svelte
+++ b/web/src/components/App.svelte
@@ -85,7 +85,7 @@
   async function generateAndPrint(size: number, pages: number): Promise<void> {
     printBusy = true;
     status = 'Generating…';
-    trackEvent('rublock/print/print');
+    trackEvent(`rublock/print/print/${size}`);
     try {
       await fillPrintOutput(size, pages);
       status = 'Ready';

--- a/web/src/components/tabs/PlayTab.svelte
+++ b/web/src/components/tabs/PlayTab.svelte
@@ -123,7 +123,7 @@
   async function shareCurrentPuzzle(): Promise<void> {
     if (!playState.puzzleData) return;
     const url = puzzleShareUrl(playState.puzzleData);
-    trackEvent('rublock/play/share');
+    trackEvent(`rublock/play/share/${playState.puzzleData.size}`);
     shareError = false;
     shareFeedback = '';
     try {

--- a/web/src/components/tabs/SolveTab.svelte
+++ b/web/src/components/tabs/SolveTab.svelte
@@ -45,7 +45,7 @@
     }
 
     feedback = 'Solved.';
-    trackEvent('rublock/solve/solve');
+    trackEvent(`rublock/solve/solve/${parsed.size}`);
     solved = response;
     setPuzzle(parsed, { preserveProgressIfSame: true });
   }

--- a/web/src/state/puzzle.svelte.ts
+++ b/web/src/state/puzzle.svelte.ts
@@ -104,7 +104,7 @@ export function setPuzzle(data: PuzzleData, options?: { preserveProgressIfSame?:
 
 export function loadRandomPuzzle(size: number): void {
   setPuzzleData(generatePuzzle(size), { preserveProgressIfSame: false });
-  trackEvent('rublock/play/generate');
+  trackEvent(`rublock/play/generate/${size}`);
 }
 
 function clearWrongCell(row: number, col: number): void {
@@ -271,13 +271,13 @@ function autoCheckCompletion(): void {
   }
   playState.feedback = 'Puzzle solved! 🎉';
   playState.feedbackError = false;
-  trackEvent('rublock/play/complete');
+  trackEvent(`rublock/play/complete/${playState.puzzleData.size}`);
   for (const cb of solveCallbacks) cb();
 }
 
 export function checkCurrentPuzzle(): void {
   if (!playState.puzzleData) return;
-  trackEvent('rublock/play/check');
+  trackEvent(`rublock/play/check/${playState.puzzleData.size}`);
 
   const response: SolveResponse = solvePuzzle(playState.puzzleData);
   playState.wrongCells.clear();


### PR DESCRIPTION
## Summary

- Append the puzzle grid size to each puzzle-specific analytics event path, e.g. `rublock/play/complete/7` for a 7×7 puzzle
- Affects all 6 puzzle-context events: `play/generate`, `play/complete`, `play/check`, `play/share`, `solve/solve`, `print/print`
- Tab-view events (`rublock/*/tab-view`) are unchanged — they carry no puzzle context

## Changes

Each `trackEvent('rublock/...')` call with a puzzle context is changed to a template literal that appends `/${size}`:

| Before | After (example) |
|---|---|
| `rublock/play/generate` | `rublock/play/generate/7` |
| `rublock/play/complete` | `rublock/play/complete/7` |
| `rublock/play/check` | `rublock/play/check/7` |
| `rublock/play/share` | `rublock/play/share/7` |
| `rublock/solve/solve` | `rublock/solve/solve/7` |
| `rublock/print/print` | `rublock/print/print/7` |

No migration needed — GoatCounter will simply start seeing the new event names going forward.

https://claude.ai/code/session_018SLqiSYTBHEeBmzzmp4fZh

---
_Generated by [Claude Code](https://claude.ai/code/session_018SLqiSYTBHEeBmzzmp4fZh)_