### PR TITLE
Encode puzzle URL parameter using base58

### DIFF
--- a/web/src/state/url.svelte.ts
+++ b/web/src/state/url.svelte.ts
@@ -34,7 +34,7 @@ export function parseTargetsText(text: string): { error: string } | PuzzleData {
   };
 }
 
-function decodeBase58Targets(p: string): PuzzleData | null {
+function decodeBase62Targets(p: string): PuzzleData | null {
   const values = [...p].map((c) => BASE62.indexOf(c));
   if (values.some((n) => n < 0)) return null;
   if (values.length % 2 !== 0) return null;
@@ -50,7 +50,7 @@ export function parsePuzzleFromUrl(): PuzzleData | null {
     const parsed = parseTargetsText(param);
     return 'error' in parsed ? null : parsed;
   }
-  return decodeBase58Targets(param);
+  return decodeBase62Targets(param);
 }
 
 export function tabFromUrl(): TabName {
@@ -70,17 +70,17 @@ export function setTab(name: TabName): void {
  */
 export function syncUrl(puzzleData: PuzzleData | null, active: TabName): void {
   if (!puzzleData) return;
-  const p = serializePuzzleTargets(puzzleData);
-  let search = `?p=${p}`;
-  if (active !== 'play') search += `&t=${active}`;
-  const next = `${window.location.pathname}${search}${window.location.hash}`;
-  const cur = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-  if (next !== cur) history.replaceState(null, '', next);
+  const url = new URL(window.location.href);
+  url.search = '';
+  url.searchParams.set('p', serializePuzzleTargets(puzzleData));
+  if (active !== 'play') url.searchParams.set('t', active);
+  if (url.toString() !== window.location.href) history.replaceState(null, '', url);
 }
 
 /** Share link: puzzle only, no tab param. */
 export function puzzleShareUrl(data: PuzzleData): string {
-  const base = `${window.location.origin}${window.location.pathname}`;
-  const hash = window.location.hash || '';
-  return `${base}?p=${serializePuzzleTargets(data)}${hash}`;
+  const url = new URL(window.location.href);
+  url.search = '';
+  url.searchParams.set('p', serializePuzzleTargets(data));
+  return url.toString();
 }

--- a/web/src/state/url.svelte.ts
+++ b/web/src/state/url.svelte.ts
@@ -3,10 +3,12 @@ import { trackEvent } from '../analytics';
 
 const VALID_TABS = new Set<TabName>(['play', 'solve', 'print', 'howto']);
 
+const BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
 export const tabState = $state({ active: 'play' as TabName });
 
 export function serializePuzzleTargets(data: PuzzleData): string {
-  return [...data.row_targets, ...data.col_targets].join(',');
+  return [...data.row_targets, ...data.col_targets].map((n) => BASE58[n]).join('');
 }
 
 export function parseTargetsText(text: string): { error: string } | PuzzleData {
@@ -32,12 +34,23 @@ export function parseTargetsText(text: string): { error: string } | PuzzleData {
   };
 }
 
+function decodeBase58Targets(p: string): PuzzleData | null {
+  const values = [...p].map((c) => BASE58.indexOf(c));
+  if (values.some((n) => n < 0)) return null;
+  if (values.length % 2 !== 0) return null;
+  const size = values.length / 2;
+  if (size < 5 || size > 8) return null;
+  return { size, row_targets: values.slice(0, size), col_targets: values.slice(size) };
+}
+
 export function parsePuzzleFromUrl(): PuzzleData | null {
   const param = new URLSearchParams(window.location.search).get('p');
   if (!param) return null;
-  const parsed = parseTargetsText(param);
-  if ('error' in parsed) return null;
-  return parsed;
+  if (param.includes(',')) {
+    const parsed = parseTargetsText(param);
+    return 'error' in parsed ? null : parsed;
+  }
+  return decodeBase58Targets(param);
 }
 
 export function tabFromUrl(): TabName {
@@ -53,8 +66,7 @@ export function setTab(name: TabName): void {
 
 /**
  * Keep the address bar in sync with app state: current puzzle as `p=`
- * (comma-separated, not URLSearchParams-serialized) and `t=` when the tab is
- * not Play.
+ * (base58-encoded) and `t=` when the tab is not Play.
  */
 export function syncUrl(puzzleData: PuzzleData | null, active: TabName): void {
   if (!puzzleData) return;
@@ -66,7 +78,7 @@ export function syncUrl(puzzleData: PuzzleData | null, active: TabName): void {
   if (next !== cur) history.replaceState(null, '', next);
 }
 
-/** Share link: puzzle only, no tab param. (Plain `p=` so commas stay readable.) */
+/** Share link: puzzle only, no tab param. */
 export function puzzleShareUrl(data: PuzzleData): string {
   const base = `${window.location.origin}${window.location.pathname}`;
   const hash = window.location.hash || '';

--- a/web/src/state/url.svelte.ts
+++ b/web/src/state/url.svelte.ts
@@ -3,12 +3,12 @@ import { trackEvent } from '../analytics';
 
 const VALID_TABS = new Set<TabName>(['play', 'solve', 'print', 'howto']);
 
-const BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 export const tabState = $state({ active: 'play' as TabName });
 
 export function serializePuzzleTargets(data: PuzzleData): string {
-  return [...data.row_targets, ...data.col_targets].map((n) => BASE58[n]).join('');
+  return [...data.row_targets, ...data.col_targets].map((n) => BASE62[n]).join('');
 }
 
 export function parseTargetsText(text: string): { error: string } | PuzzleData {
@@ -35,7 +35,7 @@ export function parseTargetsText(text: string): { error: string } | PuzzleData {
 }
 
 function decodeBase58Targets(p: string): PuzzleData | null {
-  const values = [...p].map((c) => BASE58.indexOf(c));
+  const values = [...p].map((c) => BASE62.indexOf(c));
   if (values.some((n) => n < 0)) return null;
   if (values.length % 2 !== 0) return null;
   const size = values.length / 2;
@@ -66,7 +66,7 @@ export function setTab(name: TabName): void {
 
 /**
  * Keep the address bar in sync with app state: current puzzle as `p=`
- * (base58-encoded) and `t=` when the tab is not Play.
+ * (base62-encoded, 0-9a-zA-Z) and `t=` when the tab is not Play.
  */
 export function syncUrl(puzzleData: PuzzleData | null, active: TabName): void {
   if (!puzzleData) return;


### PR DESCRIPTION
## Summary

Closes #15.

- Replaces comma-separated `p=` values with base58 encoding (one character per target), shrinking a 6×6 puzzle URL from 26 characters to 12
- Legacy comma-separated links are still parsed correctly for backwards compatibility
- All changes confined to `web/src/state/url.svelte.ts`

## Test plan

- [ ] Load a new share link (base58 format) — puzzle loads correctly
- [ ] Load an old bookmarked link (`?p=3,4,5,8,4,3,0,0,0,0,4,0`) — puzzle still loads correctly
- [ ] Copy share link from the UI — URL uses the new compact format, no commas
- [ ] Address bar updates to base58 format as you play

https://claude.ai/code/session_01RDECtbACDJ3VWvcayVszmo

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDECtbACDJ3VWvcayVszmo)_