### PR TITLE
Fix Solve tab: use comma-separated format, not base62

### DIFF
--- a/web/src/components/tabs/SolveTab.svelte
+++ b/web/src/components/tabs/SolveTab.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import PuzzleGrid from '../PuzzleGrid.svelte';
   import { setPuzzle } from '../../state/puzzle.svelte';
-  import { parseTargetsText, serializePuzzleTargets } from '../../state/url.svelte';
+  import { parseTargetsText, formatTargetsText } from '../../state/url.svelte';
   import { solvePuzzle } from '../../wasm/api';
   import { trackEvent } from '../../analytics';
   import { playState } from '../../state/puzzle.svelte';
   import type { SolvedPuzzle } from '../../state/types';
 
-  let inputText = $state(playState.puzzleData ? serializePuzzleTargets(playState.puzzleData) : '');
+  let inputText = $state(playState.puzzleData ? formatTargetsText(playState.puzzleData) : '');
   let feedback = $state('');
   let error = $state(false);
   let solved = $state<SolvedPuzzle | null>(null);
@@ -18,7 +18,7 @@
   $effect(() => {
     const data = playState.puzzleData;
     if (!data) return;
-    const serialized = serializePuzzleTargets(data);
+    const serialized = formatTargetsText(data);
     if (lastSeenKey === null || lastSeenKey !== serialized) {
       inputText = serialized;
       lastSeenKey = serialized;

--- a/web/src/state/url.svelte.ts
+++ b/web/src/state/url.svelte.ts
@@ -11,6 +11,10 @@ export function serializePuzzleTargets(data: PuzzleData): string {
   return [...data.row_targets, ...data.col_targets].map((n) => BASE62[n]).join('');
 }
 
+export function formatTargetsText(data: PuzzleData): string {
+  return [...data.row_targets, ...data.col_targets].join(',');
+}
+
 export function parseTargetsText(text: string): { error: string } | PuzzleData {
   const cleaned = text.trim();
   if (!cleaned) return { error: 'Enter targets in r1,...,rN,c1,...,cN format.' };


### PR DESCRIPTION
## Problem

After #18, the Solve tab's Targets input was being seeded with base62-encoded values (e.g. `345843000040`) instead of the human-readable comma-separated format (e.g. `3,4,5,8,4,3,0,0,0,0,4,0`). `parseTargetsText` also only accepts comma format, so submitting the pre-filled value would error.

## Fix

Add `formatTargetsText` to `url.svelte.ts` for the comma-separated representation. `SolveTab.svelte` now uses `formatTargetsText` for both seeding the input and change-detection. `serializePuzzleTargets` (base62) remains URL-only.

## Test plan

- [ ] Open Solve tab — input field shows `r1,r2,...,rN,c1,...,cN` comma format
- [ ] Hit Solve with the pre-filled value — works without error
- [ ] Share/address-bar URLs still use compact base62 encoding

https://claude.ai/code/session_01RDECtbACDJ3VWvcayVszmo

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDECtbACDJ3VWvcayVszmo)_