### PR TITLE
Add Recorder trait and Explain tab

### DIFF
--- a/web/src/components/App.svelte
+++ b/web/src/components/App.svelte
@@ -3,6 +3,7 @@
   import Header from './Header.svelte';
   import PlayTab from './tabs/PlayTab.svelte';
   import SolveTab from './tabs/SolveTab.svelte';
+  import ExplainTab from './tabs/ExplainTab.svelte';
   import PrintTab from './tabs/PrintTab.svelte';
   import HowToTab from './tabs/HowToTab.svelte';
   import PuzzleGrid from './PuzzleGrid.svelte';
@@ -104,6 +105,9 @@
   </div>
   <div style:display={tabState.active === 'solve' ? 'block' : 'none'}>
     <SolveTab />
+  </div>
+  <div style:display={tabState.active === 'explain' ? 'block' : 'none'}>
+    <ExplainTab />
   </div>
   <div style:display={tabState.active === 'print' ? 'block' : 'none'}>
     <PrintTab bind:selectedSize onPrint={generateAndPrint} busy={printBusy || !ready} />

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -10,6 +10,7 @@
   const TABS: { id: TabName; label: string }[] = [
     { id: 'play', label: 'Play' },
     { id: 'solve', label: 'Solve' },
+    { id: 'explain', label: 'Explain' },
     { id: 'print', label: 'Print' },
     { id: 'howto', label: 'How to Play' },
   ];

--- a/web/src/components/tabs/ExplainTab.svelte
+++ b/web/src/components/tabs/ExplainTab.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  import PuzzleGrid from '../PuzzleGrid.svelte';
+  import { playState } from '../../state/puzzle.svelte';
+  import { parseTargetsText, formatTargetsText } from '../../state/url.svelte';
+  import { explainPuzzle } from '../../wasm/api';
+  import { trackEvent } from '../../analytics';
+  import type { ExplainResponse, ExplainStep, RuleName } from '../../state/types';
+
+  let inputText = $state(playState.puzzleData ? formatTargetsText(playState.puzzleData) : '');
+  let feedback = $state('');
+  let error = $state(false);
+  let result = $state<ExplainResponse | null>(null);
+  let stepIndex = $state(0);
+
+  let lastSeenKey = $state<string | null>(null);
+  $effect(() => {
+    const data = playState.puzzleData;
+    if (!data) return;
+    const serialized = formatTargetsText(data);
+    if (lastSeenKey === null || lastSeenKey !== serialized) {
+      inputText = serialized;
+      lastSeenKey = serialized;
+    }
+  });
+
+  const RULE_LABELS: Record<RuleName, string> = {
+    TargetTuples: 'target constraint',
+    ArcConsistency: 'arc-consistency',
+    Singleton: 'singleton',
+    HiddenSingle: 'hidden single',
+    BlackConsistency: 'black-consistency',
+    Backtracking: 'backtracking',
+  };
+
+  function runExplain(): void {
+    error = false;
+    feedback = '';
+    result = null;
+    stepIndex = 0;
+
+    const parsed = parseTargetsText(inputText);
+    if ('error' in parsed) {
+      error = true;
+      feedback = parsed.error;
+      return;
+    }
+
+    const response = explainPuzzle(parsed);
+    if ('error' in response) {
+      error = true;
+      feedback = response.error;
+      return;
+    }
+
+    trackEvent(`rublock/explain/explain/${parsed.size}`);
+    result = response;
+    feedback = `${response.steps.length} propagation step${response.steps.length === 1 ? '' : 's'}.`;
+  }
+
+  function currentStep(): ExplainStep | null {
+    if (!result || result.steps.length === 0) return null;
+    return result.steps[stepIndex] ?? null;
+  }
+
+  function highlightedCells(): Map<string, { exNew: boolean }> {
+    const step = currentStep();
+    const map = new Map<string, { exNew: boolean }>();
+    if (!step) return map;
+    for (const e of step.events) {
+      map.set(`${e.row},${e.col}`, { exNew: true });
+    }
+    return map;
+  }
+
+  function stepSummary(step: ExplainStep): string {
+    const byRule = new Map<RuleName, number>();
+    for (const e of step.events) {
+      const removed = countBits(e.before & ~e.after);
+      byRule.set(e.rule, (byRule.get(e.rule) ?? 0) + removed);
+    }
+    return [...byRule.entries()]
+      .map(([rule, count]) => `${count} bit${count === 1 ? '' : 's'} via ${RULE_LABELS[rule]}`)
+      .join(', ');
+  }
+
+  function countBits(n: number): number {
+    let count = 0;
+    while (n) {
+      count += n & 1;
+      n >>>= 1;
+    }
+    return count;
+  }
+
+  function prev(): void {
+    if (stepIndex > 0) stepIndex--;
+  }
+
+  function next(): void {
+    if (result && stepIndex < result.steps.length - 1) stepIndex++;
+  }
+</script>
+
+<section class="tab-panel">
+  <div class="panel-card">
+    <div class="controls-row">
+      <div class="field" style="flex: 1;">
+        <label for="explain-input">Targets</label>
+        <input
+          id="explain-input"
+          type="text"
+          placeholder="r1,r2,...,rN,c1,c2,...,cN"
+          bind:value={inputText}
+        />
+      </div>
+      <button class="btn-primary" type="button" onclick={runExplain}>Explain</button>
+    </div>
+    <div class="feedback" class:error aria-live="polite">{feedback}</div>
+
+    {#if result && result.steps.length > 0}
+      {@const step = currentStep()}
+      <div class="explain-nav">
+        <button type="button" onclick={prev} disabled={stepIndex === 0}>&lsaquo; Prev</button>
+        <span class="step-counter">Step {stepIndex + 1} of {result.steps.length}</span>
+        <button type="button" onclick={next} disabled={stepIndex === result.steps.length - 1}>
+          Next &rsaquo;
+        </button>
+      </div>
+
+      {#if step}
+        <p class="step-summary">{stepSummary(step)}</p>
+        <div class="step-events">
+          {#each step.events as e (e.row + ',' + e.col + ',' + e.before + ',' + e.rule)}
+            <div class="step-event">
+              <span class="event-cell">({e.row + 1},{e.col + 1})</span>
+              <span class="event-rule">{RULE_LABELS[e.rule]}</span>
+              <span class="event-bits"
+                >{countBits(e.before & ~e.after)} bit{countBits(e.before & ~e.after) === 1
+                  ? ''
+                  : 's'} removed</span
+              >
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="explain-grid">
+        <PuzzleGrid puzzle={result} values={result.cells} cellExtras={highlightedCells()} />
+      </div>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .explain-nav {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin: 0.75rem 0 0.5rem;
+  }
+
+  .step-counter {
+    font-weight: 600;
+    min-width: 10ch;
+    text-align: center;
+  }
+
+  .step-summary {
+    color: #555;
+    font-size: 0.9rem;
+    margin: 0.25rem 0 0.5rem;
+  }
+
+  .step-events {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    max-height: 10rem;
+    overflow-y: auto;
+    margin-bottom: 0.75rem;
+    font-size: 0.85rem;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    padding: 0.4rem 0.6rem;
+  }
+
+  .step-event {
+    display: flex;
+    gap: 0.75rem;
+    color: #333;
+  }
+
+  .event-cell {
+    font-family: monospace;
+    min-width: 5ch;
+  }
+
+  .event-rule {
+    color: #666;
+    flex: 1;
+  }
+
+  .event-bits {
+    color: #999;
+    white-space: nowrap;
+  }
+
+  .explain-grid {
+    margin-top: 0.5rem;
+  }
+</style>

--- a/web/src/state/types.ts
+++ b/web/src/state/types.ts
@@ -35,4 +35,28 @@ export interface SelectedCell {
 
 export type InputMode = 'value' | 'notes';
 
-export type TabName = 'play' | 'solve' | 'print' | 'howto';
+export type TabName = 'play' | 'solve' | 'explain' | 'print' | 'howto';
+
+export type RuleName =
+  | 'TargetTuples'
+  | 'ArcConsistency'
+  | 'Singleton'
+  | 'HiddenSingle'
+  | 'BlackConsistency'
+  | 'Backtracking';
+
+export interface ExplainEvent {
+  row: number;
+  col: number;
+  before: number;
+  after: number;
+  rule: RuleName;
+}
+
+export interface ExplainStep {
+  events: ExplainEvent[];
+}
+
+export interface ExplainResponse extends SolvedPuzzle {
+  steps: ExplainStep[];
+}

--- a/web/src/state/url.svelte.ts
+++ b/web/src/state/url.svelte.ts
@@ -1,7 +1,7 @@
 import type { PuzzleData, TabName } from './types';
 import { trackEvent } from '../analytics';
 
-const VALID_TABS = new Set<TabName>(['play', 'solve', 'print', 'howto']);
+const VALID_TABS = new Set<TabName>(['play', 'solve', 'explain', 'print', 'howto']);
 
 const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 

--- a/web/src/wasm/api.ts
+++ b/web/src/wasm/api.ts
@@ -1,10 +1,10 @@
-import init, { generate_puzzle, solve_puzzle } from './pkg/rublock.js';
+import init, { generate_puzzle, solve_puzzle, explain_puzzle } from './pkg/rublock.js';
 // `?url` returns the bundled URL of the .wasm asset. We pass it explicitly to
 // `init()` instead of relying on `import.meta.url`, so Vite hashes and ships
 // the file like any other asset.
 import wasmUrl from './pkg/rublock_bg.wasm?url';
 
-import type { PuzzleData, SolveResponse } from '../state/types';
+import type { ExplainResponse, PuzzleData, SolveResponse } from '../state/types';
 
 let initPromise: Promise<unknown> | null = null;
 
@@ -23,4 +23,10 @@ export function solvePuzzle(data: PuzzleData): SolveResponse {
   return JSON.parse(
     solve_puzzle(Uint8Array.from(data.row_targets), Uint8Array.from(data.col_targets))
   ) as SolveResponse;
+}
+
+export function explainPuzzle(data: PuzzleData): ExplainResponse | { error: string } {
+  return JSON.parse(
+    explain_puzzle(Uint8Array.from(data.row_targets), Uint8Array.from(data.col_targets))
+  ) as ExplainResponse | { error: string };
 }

--- a/web/src/wasm/pkg-types.d.ts
+++ b/web/src/wasm/pkg-types.d.ts
@@ -7,4 +7,5 @@ declare module './pkg/rublock.js' {
   ): Promise<unknown>;
   export function generate_puzzle(size: number): string;
   export function solve_puzzle(rowTargets: Uint8Array, colTargets: Uint8Array): string;
+  export function explain_puzzle(rowTargets: Uint8Array, colTargets: Uint8Array): string;
 }


### PR DESCRIPTION
## Summary

Two-step refactor that turns the old `StatsHandle` into a generic `Recorder` abstraction and adds a step-by-step "Explain" tab to the web UI.

### Step 1 — Recorder refactor + `Rule::TargetTuples`
- New `recorder.rs` replaces `stats.rs`. The `Recorder` trait has empty default methods, so each implementation only handles the events it cares about.
- Two recorders ship: `SearchNodes` (one `Cell<u64>`, the cheap default for `gen_puzzle` / `compare` / wasm `solve_puzzle` / bench) and `FullStats` (per-rule bit-removal breakdown, used by `main` and the `stats_track_*` tests). The previous `#[cfg(debug_assertions)]` gate on stats fields is gone — release builds now compile in only the recorder the caller picked.
- New `Rule::TargetTuples` covers the bulk reduction `seed_queue` does up front in the black/queue solvers (bits with no live tuple support before any propagation has run). Distinct from `ArcConsistency`, which fires later when a tuple's last support disappears.
- Each solver state is now `Solver<N, R: Recorder = SearchNodes>` so existing call sites compile unchanged.
- The black/queue solvers' work queues switch from `Vec` (LIFO) to `VecDeque` (FIFO BFS order). This sets up wave-batched step boundaries in Step 2.

### Step 2 — `Explain` recorder + UI
- `Explain` (in `recorder.rs`) groups events into steps. One step = one BFS wave (black/queue), one fixpoint iteration (basic), or one branching assignment. Empty steps are discarded so the basic solver's final no-op fixpoint iteration doesn't render as a blank panel.
- All three solvers fire `on_step_start()` at the natural boundaries (before `seed_queue`, at the top of each wave, on branch take/reject).
- New `explain_puzzle` wasm entrypoint runs the black solver with the `Explain` recorder and serializes the log alongside the solved cells.
- New `ExplainTab.svelte` paginates through the steps, highlighting cells touched in each step and listing per-event bit-removal counts grouped by rule.

## Test plan

- [x] `cargo test` — 73 passed; new `explain_records_steps_for_solvable_puzzle` test verifies step boundaries, non-empty events, and `TargetTuples` attribution on the newspaper puzzle.
- [x] `cargo build --target wasm32-unknown-unknown --release --features wasm` — wasm build succeeds.
- [ ] Manual: `mise run web-dev`, paste a puzzle's targets into the Explain tab, page through the steps and confirm cell highlights and rule breakdown render.
- [ ] CI / playwright tests on the deployed branch.

https://claude.ai/code/session_01WgLsYKjtcZnJqBfXD73G2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgLsYKjtcZnJqBfXD73G2n)_