### PR TITLE
Implement the Walkthrough tab

### DIFF
--- a/web/src/components/tabs/WalkthroughTab.svelte
+++ b/web/src/components/tabs/WalkthroughTab.svelte
@@ -1,32 +1,269 @@
 <script lang="ts">
   import PageHeader from '../PageHeader.svelte';
+  import PuzzleGrid from '../PuzzleGrid.svelte';
+  import { playState, emptyNotes } from '../../state/puzzle.svelte';
+  import { explainPuzzle } from '../../wasm/api';
+  import { trackEvent } from '../../analytics';
+  import type {
+    CellNotes,
+    CellValue,
+    ExplainEvent,
+    ExplainRule,
+    ExplainStep,
+    ExplainedPuzzle,
+    PuzzleData,
+  } from '../../state/types';
 
-  // TODO: Implement step-by-step solve walkthrough.
-  // This tab should show a selected puzzle being solved one deduction at a time,
-  // with each step highlighted on the board and explained in text.
-  // See DESIGN_NOTES.md for context.
+  // Bit layout used by the wasm `explain_puzzle` (BlackSolverState):
+  //   bit 0       = "could be black"
+  //   bits 1..N-2 = "could be that digit"
+  // FULL_DOMAIN therefore has bits 0..N-2 set.
+  function fullDomain(size: number): number {
+    return (1 << (size - 1)) - 1;
+  }
+
+  function domainToCell(domain: number): { value: CellValue; notes: CellNotes } {
+    const black = (domain & 1) !== 0;
+    const digits: number[] = [];
+    for (let d = 1; d <= 7; d++) {
+      if (domain & (1 << d)) digits.push(d);
+    }
+    const total = digits.length + (black ? 1 : 0);
+    if (total === 1) {
+      return { value: black ? 'black' : digits[0], notes: emptyNotes() };
+    }
+    return {
+      value: null,
+      notes: { digits, marker: black ? 'black' : null },
+    };
+  }
+
+  type WaveView = {
+    index: number;
+    values: CellValue[][];
+    notes: CellNotes[][];
+    extras: Map<string, { exNew: true }>;
+    counts: { rule: ExplainRule; count: number }[];
+    total: number;
+  };
+
+  type WalkthroughView = { initial: WaveView; waves: WaveView[] };
+
+  function snapshotDomain(
+    size: number,
+    domain: number[][]
+  ): { values: CellValue[][]; notes: CellNotes[][] } {
+    const values: CellValue[][] = [];
+    const notes: CellNotes[][] = [];
+    for (let r = 0; r < size; r++) {
+      const vRow: CellValue[] = [];
+      const nRow: CellNotes[] = [];
+      for (let c = 0; c < size; c++) {
+        const cell = domainToCell(domain[r][c]);
+        vRow.push(cell.value);
+        nRow.push(cell.notes);
+      }
+      values.push(vRow);
+      notes.push(nRow);
+    }
+    return { values, notes };
+  }
+
+  function summarizeRules(events: ExplainEvent[]): { rule: ExplainRule; count: number }[] {
+    const counts = new Map<ExplainRule, number>();
+    for (const e of events) counts.set(e.rule, (counts.get(e.rule) ?? 0) + 1);
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([rule, count]) => ({ rule, count }));
+  }
+
+  function buildWalkthrough(puzzle: PuzzleData, steps: ExplainStep[]): WalkthroughView {
+    const domain: number[][] = Array.from({ length: puzzle.size }, () =>
+      Array.from({ length: puzzle.size }, () => fullDomain(puzzle.size))
+    );
+
+    const initialSnap = snapshotDomain(puzzle.size, domain);
+    const initial: WaveView = {
+      index: 0,
+      values: initialSnap.values,
+      notes: initialSnap.notes,
+      extras: new Map(),
+      counts: [],
+      total: 0,
+    };
+
+    const waves: WaveView[] = [];
+    steps.forEach((step, idx) => {
+      const touched = new Set<string>();
+      for (const ev of step.events) {
+        domain[ev.row][ev.col] = ev.after;
+        touched.add(`${ev.row},${ev.col}`);
+      }
+      const snap = snapshotDomain(puzzle.size, domain);
+      const extras = new Map<string, { exNew: true }>();
+      for (const k of touched) extras.set(k, { exNew: true });
+      waves.push({
+        index: idx + 1,
+        values: snap.values,
+        notes: snap.notes,
+        extras,
+        counts: summarizeRules(step.events),
+        total: step.events.length,
+      });
+    });
+
+    return { initial, waves };
+  }
+
+  // Friendly labels for the propagation rules. Wording avoids solver-internal
+  // jargon — the user does not need to know what "arc consistency" is.
+  const RULE_LABELS: Record<ExplainRule, string> = {
+    TargetTuples: 'Target sums',
+    ArcConsistency: 'Possibility check',
+    Singleton: 'Forced cells',
+    HiddenSingle: 'Only place',
+    BlackConsistency: 'Two-blacks rule',
+    Backtracking: 'Hypothesis',
+  };
+
+  const RULE_NOTES: Record<ExplainRule, string> = {
+    TargetTuples:
+      'Some digit or black placements simply cannot be part of any arrangement that adds up to the row or column target — those are removed.',
+    ArcConsistency:
+      'No remaining arrangement of this row or column still supports these options, so they are eliminated.',
+    Singleton:
+      'A nearby cell is now fully determined, and its value cannot repeat in the rest of its row or column.',
+    HiddenSingle:
+      'Only one cell in this row or column can still hold this digit or black, so the others lose it as a candidate.',
+    BlackConsistency:
+      'Each row and each column has exactly two blacks. These options would create a third one — so they go.',
+    Backtracking: 'The solver tried a guess to break a deadlock. Rare for hand-solvable puzzles.',
+  };
+
+  function rulesHeading(counts: { rule: ExplainRule; count: number }[]): string {
+    if (counts.length === 0) return '';
+    return counts.map(({ rule, count }) => `${count} · ${RULE_LABELS[rule]}`).join('   ');
+  }
+
+  function rulesExplanation(counts: { rule: ExplainRule; count: number }[]): string {
+    if (counts.length === 0) return '';
+    if (counts.length === 1) return RULE_NOTES[counts[0].rule];
+    // Several rules contributed in this wave — give the dominant rule's
+    // explanation, mentioning that others helped.
+    const [first, ...rest] = counts;
+    const others = rest.map(({ rule }) => RULE_LABELS[rule].toLowerCase()).join(', ');
+    return `${RULE_NOTES[first.rule]} The wave also includes deductions from ${others}.`;
+  }
+
+  type Result = { ok: true; data: ExplainedPuzzle } | { ok: false; error: string } | null;
+
+  let result = $state<Result>(null);
+  let lastKey = $state<string | null>(null);
+
+  $effect(() => {
+    const puzzle = playState.puzzleData;
+    if (!puzzle) {
+      result = null;
+      lastKey = null;
+      return;
+    }
+    const key = `${puzzle.size}|${puzzle.row_targets.join(',')}|${puzzle.col_targets.join(',')}`;
+    if (key === lastKey) return;
+    lastKey = key;
+    trackEvent(`rublock/walkthrough/show/${puzzle.size}`);
+    const response = explainPuzzle(puzzle);
+    if ('error' in response) {
+      result = { ok: false, error: response.error };
+    } else {
+      result = { ok: true, data: response };
+    }
+  });
+
+  let view = $derived.by<WalkthroughView | null>(() => {
+    if (!result || !result.ok) return null;
+    return buildWalkthrough(
+      {
+        size: result.data.size,
+        row_targets: result.data.row_targets,
+        col_targets: result.data.col_targets,
+      },
+      result.data.steps
+    );
+  });
+
+  let totalRemoved = $derived(view ? view.waves.reduce((n, w) => n + w.total, 0) : 0);
+
+  let statusText = $derived.by(() => {
+    if (!playState.puzzleData) return 'No puzzle loaded.';
+    if (result?.ok === false) return result.error;
+    if (!view) return '';
+    const wavesLabel = `${view.waves.length} wave${view.waves.length === 1 ? '' : 's'}`;
+    const removalsLabel = `${totalRemoved} note${totalRemoved === 1 ? '' : 's'} removed`;
+    return `${wavesLabel} · ${removalsLabel}`;
+  });
 </script>
 
-<PageHeader title="Walkthrough" status="Coming soon" />
+<PageHeader
+  title="Walkthrough"
+  status={statusText}
+  statusTone={result?.ok === false ? 'error' : 'default'}
+/>
 
 <div class="tab-content">
-  <div class="walkthrough-placeholder">
-    <!-- Steps icon -->
-    <svg
-      width="28"
-      height="28"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.7"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      style="opacity: 0.5"
-    >
-      <path d="M4 18h4v-4" />
-      <path d="M10 14h4v-4" />
-      <path d="M16 10h4V6" />
-    </svg>
-    <p style="margin-top: 10px;">Step-by-step solver — in planning.</p>
-  </div>
+  {#if !playState.puzzleData}
+    <div class="walkthrough-placeholder">
+      Pick a puzzle on the <strong>Play</strong> or <strong>Solve</strong> tab. The step-by-step solution
+      will appear here.
+    </div>
+  {:else if result?.ok === false}
+    <div class="walkthrough-placeholder" data-testid="walkthrough-error">
+      Could not generate a walkthrough: {result.error}
+    </div>
+  {:else if view}
+    <div class="card walkthrough-intro">
+      <p class="howto-prose" style="margin: 0;">
+        Watch the solver chip away at the current puzzle. Each grid below is one <strong
+          >wave</strong
+        > — every change in a wave can be made from what was known before it.
+      </p>
+      <p class="howto-prose" style="margin: 8px 0 0;">
+        Cells start with every digit (small numbers) plus an
+        <strong>x</strong> for "could be black". As options get ruled out, the notes shrink. When only
+        one option is left, the cell is filled in. Cells that changed in a wave are highlighted in yellow.
+      </p>
+    </div>
+
+    <section class="walkthrough-wave" data-testid="walkthrough-wave-initial">
+      <h2 class="walkthrough-wave-title">Start</h2>
+      <p class="walkthrough-wave-sub">Every cell could still hold any digit or be black.</p>
+      <div class="walkthrough-grid">
+        <PuzzleGrid
+          puzzle={playState.puzzleData}
+          values={view.initial.values}
+          notes={view.initial.notes}
+        />
+      </div>
+    </section>
+
+    {#each view.waves as wave (wave.index)}
+      <section class="walkthrough-wave" data-testid="walkthrough-wave">
+        <h2 class="walkthrough-wave-title">
+          Wave {wave.index}
+          <span class="walkthrough-wave-count"
+            >· {wave.total} note{wave.total === 1 ? '' : 's'} removed</span
+          >
+        </h2>
+        <p class="walkthrough-wave-rules">{rulesHeading(wave.counts)}</p>
+        <p class="walkthrough-wave-sub">{rulesExplanation(wave.counts)}</p>
+        <div class="walkthrough-grid">
+          <PuzzleGrid
+            puzzle={playState.puzzleData}
+            values={wave.values}
+            notes={wave.notes}
+            cellExtras={wave.extras}
+          />
+        </div>
+      </section>
+    {/each}
+  {/if}
 </div>

--- a/web/src/state/types.ts
+++ b/web/src/state/types.ts
@@ -19,6 +19,32 @@ export interface SolvedPuzzle extends PuzzleData {
 
 export type SolveResponse = SolvedPuzzle | { error: string };
 
+export type ExplainRule =
+  | 'TargetTuples'
+  | 'ArcConsistency'
+  | 'Singleton'
+  | 'HiddenSingle'
+  | 'BlackConsistency'
+  | 'Backtracking';
+
+export interface ExplainEvent {
+  row: number;
+  col: number;
+  before: number;
+  after: number;
+  rule: ExplainRule;
+}
+
+export interface ExplainStep {
+  events: ExplainEvent[];
+}
+
+export interface ExplainedPuzzle extends SolvedPuzzle {
+  steps: ExplainStep[];
+}
+
+export type ExplainResponse = ExplainedPuzzle | { error: string };
+
 export interface CellOperation {
   row: number;
   col: number;

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -556,7 +556,7 @@ body {
   font-size: 11.5px;
 }
 
-/* ── Walkthrough placeholder ── */
+/* ── Walkthrough tab ── */
 
 .walkthrough-placeholder {
   background: var(--card);
@@ -567,6 +567,67 @@ body {
   color: var(--muted);
   font-size: 13px;
   line-height: 1.5;
+}
+
+.walkthrough-intro {
+  margin-bottom: 14px;
+}
+
+.walkthrough-wave {
+  background: var(--card);
+  border: 1px solid var(--line-2);
+  border-radius: 16px;
+  padding: 12px 14px 14px;
+  box-shadow: var(--shadow-card);
+  margin-bottom: 14px;
+}
+
+.walkthrough-wave-title {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.walkthrough-wave-count {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: -0.005em;
+}
+
+.walkthrough-wave-rules {
+  margin-top: 4px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--accent-soft-ink);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-variant-numeric: tabular-nums;
+}
+
+.walkthrough-wave-sub {
+  margin-top: 4px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+
+.walkthrough-grid {
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+}
+
+.walkthrough-wave .puzzle td,
+.walkthrough-wave .puzzle th {
+  width: 2.1rem;
+  height: 2.1rem;
+  font-size: 0.92rem;
 }
 
 /* ── Feedback / feedback error ── */

--- a/web/src/wasm/api.ts
+++ b/web/src/wasm/api.ts
@@ -1,10 +1,10 @@
-import init, { generate_puzzle, solve_puzzle } from './pkg/rublock.js';
+import init, { generate_puzzle, solve_puzzle, explain_puzzle } from './pkg/rublock.js';
 // `?url` returns the bundled URL of the .wasm asset. We pass it explicitly to
 // `init()` instead of relying on `import.meta.url`, so Vite hashes and ships
 // the file like any other asset.
 import wasmUrl from './pkg/rublock_bg.wasm?url';
 
-import type { PuzzleData, SolveResponse } from '../state/types';
+import type { ExplainResponse, PuzzleData, SolveResponse } from '../state/types';
 
 let initPromise: Promise<unknown> | null = null;
 
@@ -23,4 +23,10 @@ export function solvePuzzle(data: PuzzleData): SolveResponse {
   return JSON.parse(
     solve_puzzle(Uint8Array.from(data.row_targets), Uint8Array.from(data.col_targets))
   ) as SolveResponse;
+}
+
+export function explainPuzzle(data: PuzzleData): ExplainResponse {
+  return JSON.parse(
+    explain_puzzle(Uint8Array.from(data.row_targets), Uint8Array.from(data.col_targets))
+  ) as ExplainResponse;
 }

--- a/web/src/wasm/pkg-types.d.ts
+++ b/web/src/wasm/pkg-types.d.ts
@@ -7,4 +7,5 @@ declare module './pkg/rublock.js' {
   ): Promise<unknown>;
   export function generate_puzzle(size: number): string;
   export function solve_puzzle(rowTargets: Uint8Array, colTargets: Uint8Array): string;
+  export function explain_puzzle(rowTargets: Uint8Array, colTargets: Uint8Array): string;
 }

--- a/web/tests/walkthrough-tab.spec.ts
+++ b/web/tests/walkthrough-tab.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+// "Newspaper puzzle 1" — the same 6×6 puzzle the Rust solver tests pin against
+// (see src/basic_solver.rs and src/black_solver.rs):
+//   row_targets = [8, 2, 3, 8, 9, 0]
+//   col_targets = [0, 0, 5, 9, 0, 4]
+// Encoded with the BASE62 URL scheme used by url.svelte.ts.
+const NEWSPAPER_URL = '/?p=823890005904';
+
+const walkthroughTabButton = (page: import('@playwright/test').Page) =>
+  page.locator('nav.bottom-nav').getByRole('button', { name: 'Walkthrough' });
+
+async function waitForReady(page: import('@playwright/test').Page) {
+  await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
+}
+
+test('walkthrough tab renders the start grid plus one grid per wave', async ({ page }) => {
+  await page.goto(NEWSPAPER_URL);
+  await waitForReady(page);
+
+  await walkthroughTabButton(page).click();
+  await expect(page.locator('.page-title')).toHaveText('Walkthrough');
+
+  // The "Start" grid is always present, then at least one wave grid.
+  await expect(page.locator('[data-testid="walkthrough-wave-initial"]')).toBeVisible();
+  const waves = page.locator('[data-testid="walkthrough-wave"]');
+  await expect(waves.first()).toBeVisible();
+  expect(await waves.count()).toBeGreaterThan(0);
+
+  // Status line summarizes the wave count.
+  await expect(page.locator('[role="status"]')).toContainText(/wave/);
+});
+
+test('the start grid has every cell showing the full notes (every digit + black marker)', async ({
+  page,
+}) => {
+  await page.goto(NEWSPAPER_URL);
+  await waitForReady(page);
+  await walkthroughTabButton(page).click();
+
+  const startGrid = page.locator('[data-testid="walkthrough-wave-initial"] table.puzzle');
+  await expect(startGrid).toBeVisible();
+
+  // 6×6 puzzle ⇒ digits 1..4 must appear in every cell, plus an "x" marker.
+  const cells = startGrid.locator('tbody td.cell');
+  await expect(cells).toHaveCount(36);
+
+  // Inspect the first cell as a representative — every cell starts identically.
+  const firstCell = cells.first();
+  for (const digit of ['1', '2', '3', '4']) {
+    await expect(firstCell.locator(`.note.note-${digit}`)).toHaveText(digit);
+  }
+  await expect(firstCell.locator('.note-marker')).toHaveText('x');
+
+  // No cell is decided in the start grid — no `.cell-value` and no `.cell.black`.
+  await expect(startGrid.locator('.cell .cell-value')).toHaveCount(0);
+  await expect(startGrid.locator('.cell.black')).toHaveCount(0);
+});
+
+test('each wave highlights the cells it modified', async ({ page }) => {
+  await page.goto(NEWSPAPER_URL);
+  await waitForReady(page);
+  await walkthroughTabButton(page).click();
+
+  const firstWave = page.locator('[data-testid="walkthrough-wave"]').first();
+  await expect(firstWave).toBeVisible();
+
+  // The yellow `ex-new` class is applied to every cell touched by the wave.
+  const highlighted = firstWave.locator('.cell.ex-new');
+  expect(await highlighted.count()).toBeGreaterThan(0);
+
+  // The Start grid never highlights anything.
+  await expect(page.locator('[data-testid="walkthrough-wave-initial"] .cell.ex-new')).toHaveCount(
+    0
+  );
+});
+
+test('the final wave shows a fully solved grid', async ({ page }) => {
+  await page.goto(NEWSPAPER_URL);
+  await waitForReady(page);
+  await walkthroughTabButton(page).click();
+
+  const lastWave = page.locator('[data-testid="walkthrough-wave"]').last();
+  await expect(lastWave).toBeVisible();
+
+  // A solved 6×6 puzzle has exactly 12 black cells (2 per row, 6 rows).
+  await expect(lastWave.locator('.cell.black')).toHaveCount(12);
+  // Every other cell is a determined digit (24 cells with `.cell-value`).
+  await expect(lastWave.locator('.cell .cell-value')).toHaveCount(24);
+  // No more notes anywhere on the final wave.
+  await expect(lastWave.locator('.cell .cell-notes')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

Replaces the placeholder Walkthrough tab with a real step-by-step solver replay, driven by the existing `Explain` recorder in the wasm crate.

- Wires `explain_puzzle` into the TS wasm API and adds matching types in `state/types.ts`.
- The tab renders a "Start" grid (every cell shows every digit plus an `x` for "could be black"), then one grid per propagation **wave**. Each wave grid shows the cumulative domain after that wave's bit removals: cells with multiple options keep their notes, singletons resolve to a digit or a black square. Cells touched by the wave are highlighted in yellow (the same `ex-new` style the How‑to‑play tab uses).
- Each wave header lists the rules that fired (with friendly labels — no solver-internal jargon) and a short prose explanation, so the reader can follow what kind of deduction the solver just made.
- Adds a Playwright spec (`web/tests/walkthrough-tab.spec.ts`) built around the same "newspaper puzzle 1" the Rust solver tests pin to. It checks that the start grid is fully populated with notes, that wave grids highlight the cells they modified, and that the final wave shows a fully solved 6×6 board (12 black cells, 24 digit cells, no leftover notes).

## Test plan

- [x] `cargo test --lib` (73 passed, no Rust changes anyway)
- [x] `wasm-pack build --target web --dev --features wasm` (verifies `explain_puzzle` is exported)
- [x] `npm run check` in `web/` (svelte-check, 0 errors)
- [x] `npm run build` in `web/`
- [x] `npx playwright test` against the production preview — all 29 tests pass, including the 4 new walkthrough specs
- [x] `npx prettier --check src tests` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01RcTVcoYDEb2q3VzWb3SV6t)_