### PR TITLE
Create tab: highlight target values that yield unique puzzles

### DIFF
--- a/web/src/components/tabs/CreateTab.svelte
+++ b/web/src/components/tabs/CreateTab.svelte
@@ -12,6 +12,7 @@
     classificationTone,
     type ClassificationResult,
   } from '../../state/classification';
+  import type { PuzzleData } from '../../state/types';
   import {
     SUPPORTED_SIZES,
     activeDraft,
@@ -34,10 +35,12 @@
   function handleSizeClick(s: SupportedSize): void {
     if (s === createState.size) return;
     ensureDraft(s);
+    refreshValidValues();
   }
 
   function handleTargetClick(axis: 'row' | 'col', index: number): void {
     selectTarget(axis, index);
+    refreshValidValues();
   }
 
   function handleValueClick(value: number): void {
@@ -104,6 +107,56 @@
   let max = $derived(maxTargetForSize(createState.size));
   let values = $derived(Array.from({ length: max + 1 }, (_, i) => i));
   let valueStripDisabled = $derived(draft?.selected == null);
+
+  // ── Per-value validity ─────────────────────────────────────────────────────
+  // For the currently selected target, classify the puzzle that would result
+  // from each candidate value 0..=max. Buttons backed by `unique`-solution
+  // values get a "valid" highlight; unclassified buttons stay neutral so the
+  // user can still tap them (they're not disabled).
+  //
+  // We classify one value at a time and yield to the event loop between calls
+  // so the UI stays responsive on size 8. A monotonically increasing token
+  // cancels the in-flight loop whenever the relevant inputs change.
+  let validValues = $state<(boolean | undefined)[]>([]);
+  let classifyToken = 0;
+
+  function refreshValidValues(): void {
+    const d = activeDraft();
+    classifyToken++;
+    if (!d || !d.selected) {
+      validValues = [];
+      return;
+    }
+    const sel = { axis: d.selected.axis, index: d.selected.index };
+    const m = maxTargetForSize(d.size);
+    const rowSnap = [...d.rowTargets];
+    const colSnap = [...d.colTargets];
+    const myToken = classifyToken;
+    validValues = new Array<boolean | undefined>(m + 1).fill(undefined);
+
+    void (async () => {
+      for (let v = 0; v <= m; v++) {
+        if (myToken !== classifyToken) return;
+        const puzzle: PuzzleData = {
+          row_targets: [...rowSnap],
+          col_targets: [...colSnap],
+        };
+        if (sel.axis === 'row') puzzle.row_targets[sel.index] = v;
+        else puzzle.col_targets[sel.index] = v;
+        let isValid = false;
+        try {
+          isValid = classifyPuzzle(puzzle).variant === 'unique';
+        } catch {
+          isValid = false;
+        }
+        if (myToken !== classifyToken) return;
+        validValues[v] = isValid;
+        // Yield so the browser can paint the freshly classified button and
+        // process input before we tackle the next value.
+        await new Promise<void>((r) => setTimeout(r, 0));
+      }
+    })();
+  }
 </script>
 
 <PageHeader
@@ -150,9 +203,12 @@
       <button
         type="button"
         class="create-value-btn"
+        class:valid={validValues[v] === true}
         disabled={valueStripDisabled}
         onclick={() => handleValueClick(v)}
         aria-label={`Set target to ${v}`}
+        data-classified={validValues[v] !== undefined}
+        data-valid={validValues[v] === true}
       >
         {v}
       </button>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -475,6 +475,19 @@ body {
   background: var(--tint);
 }
 
+/* Highlight values that lead to a uniquely-solvable puzzle for the
+   currently selected target. Other values are not disabled — the user
+   can still pick them and see the resulting status in the header. */
+.create-value-btn.valid {
+  border-color: var(--success);
+  background: color-mix(in oklab, var(--success) 14%, var(--card));
+  color: color-mix(in oklab, var(--success) 60%, var(--ink));
+}
+
+.create-value-btn.valid:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--success) 22%, var(--card));
+}
+
 /* ── How-to tab ── */
 
 .howto-prose {

--- a/web/tests/create-tab.spec.ts
+++ b/web/tests/create-tab.spec.ts
@@ -113,6 +113,47 @@ test('share copies a URL for valid puzzles', async ({ page, context }) => {
   expect(clipboardText).toMatch(/\?p=[0-9a-zA-Z]+/);
 });
 
+test('selecting a target highlights values that lead to valid puzzles', async ({ page }) => {
+  // Hard-coded size-6 puzzle: row=[7,0,4,7,4,3], col=[0,10,4,1,0,0].
+  // It has a unique solution, so keeping row 0 at 7 stays valid.
+  await page.goto('/?p=7047430a4100');
+  await waitForReady(page);
+  await page.locator('nav.bottom-nav').getByRole('button', { name: 'Create' }).click();
+  await expect(page.locator('.page-title')).toHaveText('Create');
+
+  // Select the first row target.
+  await page.locator('.app-shell table.puzzle th[scope="row"].target').first().click();
+
+  const valueButtons = page.locator('.create-values .create-value-btn');
+  // Size 6 → max target is (6-2)*(6-1)/2 = 10, so 11 buttons (0..10).
+  await expect(valueButtons).toHaveCount(11);
+
+  // Classification runs sequentially 0..max, so once the last button is
+  // marked classified every other one is too.
+  await expect(valueButtons.last()).toHaveAttribute('data-classified', 'true');
+
+  // Buttons stay tappable regardless of validity.
+  for (let i = 0; i < 11; i++) {
+    await expect(valueButtons.nth(i)).toBeEnabled();
+  }
+
+  // The current target value (7) is part of a uniquely-solvable puzzle, so
+  // it must be marked valid.
+  await expect(page.getByRole('button', { name: 'Set target to 7' })).toHaveAttribute(
+    'data-valid',
+    'true'
+  );
+
+  // At least one other value must be invalid for this target — otherwise the
+  // highlight would be useless. We don't hard-code which one to keep the
+  // test robust against solver tweaks.
+  const validCount = await valueButtons.evaluateAll(
+    (els) => els.filter((el) => el.getAttribute('data-valid') === 'true').length
+  );
+  expect(validCount).toBeGreaterThan(0);
+  expect(validCount).toBeLessThan(11);
+});
+
 test('share toasts an error when the draft has multiple solutions', async ({ page }) => {
   await openCreateTab(page);
 


### PR DESCRIPTION
## Summary

Closes #35.

When the user selects a target on the Create tab, classify the puzzle that would result from each candidate value `0..=max` and highlight the value buttons whose substitution yields a uniquely-solvable puzzle. Other buttons stay enabled so the user can still pick them and see the corresponding "no solution" / "multiple solutions" status in the header.

- Classification runs entirely in JavaScript on top of the existing `classify_puzzle` wasm entry point.
- Each value is classified one at a time with a `setTimeout(0)` yield in between so the UI stays responsive on size 8.
- A monotonically increasing token cancels the in-flight loop whenever the selection or any target value changes, so we never apply stale results.
- Valid buttons get a soft success-tinted highlight (via `.create-value-btn.valid`) and `data-valid="true"`. Every classified button carries `data-classified="true"` so tests can wait for completion.

## Test plan

- [x] `npm run check` passes.
- [x] `npm run build:test` passes.
- [ ] New Playwright test (`selecting a target highlights values that lead to valid puzzles`) — verified locally that the build picks it up; the chromium binary couldn't be downloaded in this sandbox so the test will run in CI.
- [ ] Manual smoke test in `mise run web-dev`: select a row target on size 6, observe a few buttons turn green within ~100 ms; flip another target value and confirm the highlights update.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJMjJvZP5Lag2mbjAMqmwS)_