### PR TITLE
Catch wasm panics gracefully in the web frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +585,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "rublock"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "criterion",
  "getrandom",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ authors = ["Jonas Wagner <jonas@purpureus.net>"]
 crate-type = ["cdylib", "rlib"]
 
 [features]
-wasm = ["dep:wasm-bindgen", "dep:serde", "dep:serde-wasm-bindgen"]
+wasm = [
+    "dep:wasm-bindgen",
+    "dep:serde",
+    "dep:serde-wasm-bindgen",
+    "dep:console_error_panic_hook",
+]
 
 [dependencies]
 rayon = "1"
@@ -25,6 +30,7 @@ rand = "0.10.0"
 wasm-bindgen = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -98,6 +98,17 @@ impl From<Rule> for RuleOut {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
+/// Install a panic hook that turns Rust panics into JavaScript exceptions
+/// with a useful message. Without it, a panic surfaces as an opaque
+/// `RuntimeError: unreachable executed` and the wasm instance is poisoned.
+/// The hook is a defense-in-depth measure — every external input is already
+/// validated at the boundary, but if a solver bug triggers a panic we'd
+/// rather show the user a real error than a frozen UI.
+#[wasm_bindgen(start)]
+pub fn _wasm_start() {
+    console_error_panic_hook::set_once();
+}
+
 fn js_err(msg: &str) -> JsValue {
     JsValue::from_str(msg)
 }

--- a/web/src/components/App.svelte
+++ b/web/src/components/App.svelte
@@ -8,6 +8,7 @@
   import WalkthroughTab from './tabs/WalkthroughTab.svelte';
   import PuzzleGrid from './PuzzleGrid.svelte';
   import { initWasm, generatePuzzle } from '../wasm/api';
+  import { reportFatal } from '../error-overlay';
   import { loadRandomPuzzle, setPuzzle } from '../state/puzzle.svelte';
   import {
     parsePuzzleFromUrl,
@@ -48,7 +49,7 @@
       ready = true;
     } catch (err) {
       console.error('Initialization failed:', err);
-      throw err;
+      reportFatal(err);
     }
   });
 

--- a/web/src/error-overlay.ts
+++ b/web/src/error-overlay.ts
@@ -1,0 +1,80 @@
+// Defense-in-depth: any error that escapes a try/catch — a Rust panic that
+// surfaces as a JS exception, an unhandled promise rejection, a programming
+// bug — would otherwise leave the user staring at a frozen page. We listen
+// once at startup and replace the screen with a user-visible banner so the
+// failure mode is obvious and recoverable (refresh).
+
+let overlayShown = false;
+
+function describe(err: unknown): string {
+  if (err instanceof Error) return err.message || err.toString();
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function showOverlay(message: string): void {
+  if (overlayShown) return;
+  overlayShown = true;
+  const el = document.createElement('div');
+  el.setAttribute('role', 'alert');
+  el.dataset.testid = 'error-overlay';
+  el.style.cssText = [
+    'position:fixed',
+    'inset:0',
+    'z-index:9999',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'padding:24px',
+    'background:rgba(20,20,40,0.45)',
+    'font-family:inherit',
+  ].join(';');
+  const card = document.createElement('div');
+  card.style.cssText = [
+    'max-width:420px',
+    'background:#fff',
+    'color:#222',
+    'border-radius:14px',
+    'padding:20px 22px',
+    'box-shadow:0 6px 24px rgba(0,0,0,0.18)',
+  ].join(';');
+  const title = document.createElement('h2');
+  title.textContent = 'Something went wrong';
+  title.style.cssText = 'margin:0 0 8px;font-size:1.1rem;';
+  const body = document.createElement('p');
+  body.textContent = message;
+  body.style.cssText = 'margin:0 0 14px;color:#444;white-space:pre-wrap;';
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Reload';
+  btn.style.cssText = [
+    'padding:8px 14px',
+    'border:0',
+    'border-radius:8px',
+    'background:#3346c8',
+    'color:#fff',
+    'font:inherit',
+    'cursor:pointer',
+  ].join(';');
+  btn.addEventListener('click', () => window.location.reload());
+  card.append(title, body, btn);
+  el.appendChild(card);
+  document.body.appendChild(el);
+}
+
+export function installErrorOverlay(): void {
+  window.addEventListener('error', (ev) => {
+    showOverlay(describe(ev.error ?? ev.message));
+  });
+  window.addEventListener('unhandledrejection', (ev) => {
+    showOverlay(describe(ev.reason));
+  });
+}
+
+export function reportFatal(err: unknown): void {
+  showOverlay(describe(err));
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,7 +1,10 @@
 import { mount } from 'svelte';
 import App from './components/App.svelte';
+import { installErrorOverlay } from './error-overlay';
 import './styles/global.css';
 import './styles/puzzle.css';
+
+installErrorOverlay();
 
 const target = document.getElementById('app');
 if (!target) throw new Error('#app mount point missing from index.html');

--- a/web/tests/invalid-input.spec.ts
+++ b/web/tests/invalid-input.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+// BASE62 char 'h' = 17. For a 5x5 puzzle, the maximum achievable target is
+// (5-2)*(5-1)/2 = 6, so all-17 row/col targets are out of range. The puzzle
+// is reachable through a share URL, so the WASM boundary must reject it
+// without panicking and the UI must surface a readable error rather than
+// freezing or throwing an uncaught exception.
+const OUT_OF_RANGE_URL = '/?p=hhhhhhhhhh';
+
+const walkthroughTabButton = (page: import('@playwright/test').Page) =>
+  page.locator('nav.bottom-nav').getByRole('button', { name: 'Walkthrough' });
+
+test('out-of-range targets in a share URL do not crash the app', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+  await page.goto(OUT_OF_RANGE_URL);
+
+  // The puzzle grid still renders — the Play tab is independent of any
+  // solver call, so a bad puzzle just shows up as bad targets.
+  await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
+
+  // No fatal error overlay was triggered: the bad input was rejected at the
+  // WASM boundary rather than panicking past it.
+  await expect(page.locator('[data-testid="error-overlay"]')).toHaveCount(0);
+  expect(consoleErrors).toEqual([]);
+});
+
+test('walkthrough tab shows a friendly error for out-of-range targets', async ({ page }) => {
+  await page.goto(OUT_OF_RANGE_URL);
+  await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
+
+  await walkthroughTabButton(page).click();
+
+  // The walkthrough catches the WASM error and surfaces the validation
+  // message verbatim — "target N is out of range (max is M for size K)".
+  const error = page.locator('[data-testid="walkthrough-error"]');
+  await expect(error).toBeVisible();
+  await expect(error).toContainText(/out of range/);
+});


### PR DESCRIPTION
Closes part of #22.

The first half of the issue — validating external inputs so the solver
can't be panicked from JavaScript — was already addressed in 55f46cd
(`Puzzle::try_new`, used by both `wasm.rs` and `main.rs`).

This PR addresses the remaining "defense in depth" half: if a solver
bug ever panics despite the input checks, the user should see a real
error rather than a frozen UI.

## Summary

- Install `console_error_panic_hook` in the wasm crate so a Rust panic
  surfaces as a JS exception with a readable message instead of an
  opaque `RuntimeError: unreachable executed`.
- Add a global `error` / `unhandledrejection` listener in `main.ts`
  that overlays a "Something went wrong — Reload" card when an
  exception escapes a `try`/`catch`.
- Treat a failed `initWasm()` as fatal-but-visible rather than
  rethrowing into a blank page.
- New Playwright spec exercises the input-validation chain end-to-end:
  an out-of-range share URL renders the Play tab, never trips the
  overlay, and the Walkthrough tab shows the validator's friendly
  error.

## Test plan

- [x] `cargo test` (81 passed)
- [x] `npm run check` (0 errors, 0 warnings)
- [x] `npm run build`
- [ ] Playwright suite (browser download blocked in this environment;
      will run in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FQNFa2fRQL7rzwDRpE4F5T)_