### PR TITLE
Show difficulty / validity chip on the Play tab

### DIFF
--- a/web/src/components/tabs/CreateTab.svelte
+++ b/web/src/components/tabs/CreateTab.svelte
@@ -7,7 +7,11 @@
   import { shareUrl } from '../../share';
   import { trackEvent } from '../../analytics';
   import { classifyPuzzle } from '../../wasm/api';
-  import type { ClassifiedPuzzle } from '../../state/types';
+  import {
+    classificationLabel,
+    classificationTone,
+    type ClassificationResult,
+  } from '../../state/classification';
   import {
     SUPPORTED_SIZES,
     activeDraft,
@@ -42,8 +46,10 @@
 
   // ── Live classification ────────────────────────────────────────────────────
   // We re-run `classify_puzzle` whenever the draft's targets change. The wasm
-  // call is cheap for small sizes (5–7) and tolerable on 8.
-  let classification = $state<ClassifiedPuzzle | { error: string } | null>(null);
+  // call is cheap for small sizes (5–7) and tolerable on 8. Drafts are
+  // user-edited targets so we don't reuse the shared cache here — every edit
+  // produces a new key anyway.
+  let classification = $state<ClassificationResult | null>(null);
 
   $effect(() => {
     if (!draft) {
@@ -57,44 +63,6 @@
       classification = { error: err instanceof Error ? err.message : String(err) };
     }
   });
-
-  type Difficulty = 'invalid' | 'normal' | 'hard' | 'very-hard' | 'extremely-hard';
-
-  function difficulty(c: ClassifiedPuzzle, size: number): Difficulty {
-    if (c.variant !== 'unique') return 'invalid';
-    if (c.search_nodes <= 1) return 'normal';
-    if (c.search_nodes <= size) return 'hard';
-    if (c.search_nodes > 100) return 'extremely-hard';
-    return 'very-hard';
-  }
-
-  function statusLabel(c: ClassifiedPuzzle | { error: string } | null, size: number): string {
-    if (!c) return '';
-    if ('error' in c) return c.error;
-    if (c.variant === 'unsolvable') return 'No solution';
-    if (c.variant === 'multiple') return 'Multiple solutions';
-    switch (difficulty(c, size)) {
-      case 'normal':
-        return 'Normal';
-      case 'hard':
-        return 'Hard';
-      case 'very-hard':
-        return 'Very hard';
-      case 'extremely-hard':
-        return 'Extremely hard';
-      default:
-        return '';
-    }
-  }
-
-  function statusTone(
-    c: ClassifiedPuzzle | { error: string } | null
-  ): 'default' | 'error' | 'success' {
-    if (!c) return 'default';
-    if ('error' in c) return 'error';
-    if (c.variant === 'unique') return 'success';
-    return 'error';
-  }
 
   let isUnique = $derived(
     classification !== null && !('error' in classification) && classification.variant === 'unique'
@@ -125,8 +93,12 @@
     await shareUrl(url);
   }
 
-  let displayStatus = $derived(toastState.text || statusLabel(classification, createState.size));
-  let displayTone = $derived(toastState.text ? toastState.tone : statusTone(classification));
+  let displayStatus = $derived(
+    toastState.text || classificationLabel(classification, createState.size)
+  );
+  let displayTone = $derived(
+    toastState.text ? toastState.tone : classificationTone(classification)
+  );
 
   // ── Value strip ────────────────────────────────────────────────────────────
   let max = $derived(maxTargetForSize(createState.size));

--- a/web/src/components/tabs/PlayTab.svelte
+++ b/web/src/components/tabs/PlayTab.svelte
@@ -23,6 +23,11 @@
   import { trackEvent } from '../../analytics';
   import { toastState } from '../../state/toast.svelte';
   import { shareUrl } from '../../share';
+  import {
+    classifyCached,
+    classificationLabel,
+    classificationTone,
+  } from '../../state/classification';
 
   let showEmojiRain = $state(false);
   let hintDismissed = $state<boolean>(
@@ -35,10 +40,23 @@
     })()
   );
 
-  let status = $state('Ready');
+  let status = $state('');
 
-  let displayStatus = $derived(toastState.text || status);
-  let displayTone = $derived(toastState.text ? toastState.tone : 'info');
+  // Classification of the active puzzle. Driven by `classify_puzzle` and cached
+  // by puzzle targets, so size switches and "Use this puzzle" never re-classify
+  // a puzzle we've already seen. Generated puzzles are always Normal but we
+  // call `classify_puzzle` regardless — the cost is negligible at sizes 5–8.
+  let classification = $derived(playState.puzzleData ? classifyCached(playState.puzzleData) : null);
+  let currentSize = $derived(playState.puzzleData?.row_targets.length ?? 6);
+  let classificationStatus = $derived(classificationLabel(classification, currentSize));
+  let classificationStatusTone = $derived(classificationTone(classification));
+
+  // Toast wins (it's transient feedback). Otherwise show transient
+  // "Generating…/Switching…" if set, otherwise the classification chip.
+  let displayStatus = $derived(toastState.text || status || classificationStatus);
+  let displayTone = $derived(
+    toastState.text ? toastState.tone : status ? 'default' : classificationStatusTone
+  );
 
   onMount(() => {
     const offSolved = onSolved(() => {
@@ -134,7 +152,7 @@
   function handleSizeClick(s: number): void {
     status = 'Switching…';
     switchToSize(s);
-    status = 'Ready';
+    status = '';
   }
 
   function handleNewPuzzle(): void {
@@ -142,7 +160,7 @@
     status = 'Generating…';
     queueMicrotask(() => {
       newPuzzle(playState.puzzleData!.row_targets.length);
-      status = 'Ready';
+      status = '';
     });
   }
 
@@ -165,7 +183,6 @@
   let notesMode = $derived(playState.inputMode === 'notes');
 
   const SIZES = [5, 6, 7, 8];
-  let currentSize = $derived(playState.puzzleData?.row_targets.length ?? 6);
 </script>
 
 <PageHeader

--- a/web/src/state/classification.ts
+++ b/web/src/state/classification.ts
@@ -1,0 +1,60 @@
+import type { ClassifiedPuzzle, PuzzleData } from './types';
+import { classifyPuzzle } from '../wasm/api';
+import { puzzleKey } from './puzzle.svelte';
+
+export type ClassificationResult = ClassifiedPuzzle | { error: string };
+
+export type Difficulty = 'invalid' | 'normal' | 'hard' | 'very-hard' | 'extremely-hard';
+
+export function difficulty(c: ClassifiedPuzzle, size: number): Difficulty {
+  if (c.variant !== 'unique') return 'invalid';
+  if (c.search_nodes <= 1) return 'normal';
+  if (c.search_nodes <= size) return 'hard';
+  if (c.search_nodes > 100) return 'extremely-hard';
+  return 'very-hard';
+}
+
+export function classificationLabel(c: ClassificationResult | null, size: number): string {
+  if (!c) return '';
+  if ('error' in c) return c.error;
+  if (c.variant === 'unsolvable') return 'No solution';
+  if (c.variant === 'multiple') return 'Multiple solutions';
+  switch (difficulty(c, size)) {
+    case 'normal':
+      return 'Normal';
+    case 'hard':
+      return 'Hard';
+    case 'very-hard':
+      return 'Very hard';
+    case 'extremely-hard':
+      return 'Extremely hard';
+    default:
+      return '';
+  }
+}
+
+export function classificationTone(
+  c: ClassificationResult | null
+): 'default' | 'error' | 'success' {
+  if (!c) return 'default';
+  if ('error' in c) return 'error';
+  if (c.variant === 'unique') return 'success';
+  return 'error';
+}
+
+const cache = new Map<string, ClassificationResult>();
+
+/** Classify `data`, caching by puzzle targets so repeat calls are free. */
+export function classifyCached(data: PuzzleData): ClassificationResult {
+  const key = puzzleKey(data);
+  let entry = cache.get(key);
+  if (!entry) {
+    try {
+      entry = classifyPuzzle(data);
+    } catch (err) {
+      entry = { error: err instanceof Error ? err.message : String(err) };
+    }
+    cache.set(key, entry);
+  }
+  return entry;
+}

--- a/web/tests/app-loads.spec.ts
+++ b/web/tests/app-loads.spec.ts
@@ -8,12 +8,13 @@ test('app loads and the puzzle grid is visible on the Play tab', async ({ page }
   await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
 });
 
-test('Play tab shows "Ready" status after load', async ({ page }) => {
+test('Play tab shows the difficulty chip after load', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
 
-  // PageHeader renders a [role="status"] element with the current tab status.
-  await expect(page.locator('[role="status"]')).toHaveText('Ready');
+  // Generated puzzles are always Normal — see classify_puzzle wiring in
+  // PlayTab.svelte. The chip lives in the page header's [role="status"].
+  await expect(page.locator('[role="status"]')).toHaveText('Normal');
 });
 
 test('Play tab is active by default', async ({ page }) => {

--- a/web/tests/play-tab-chip.spec.ts
+++ b/web/tests/play-tab-chip.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForReady(page: import('@playwright/test').Page) {
+  await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
+}
+
+test('chip shows "Normal" for a freshly generated puzzle', async ({ page }) => {
+  await page.goto('/');
+  await waitForReady(page);
+  await expect(page.locator('[role="status"]')).toHaveText('Normal');
+});
+
+test('chip shows "No solution" for an unsolvable share URL', async ({ page }) => {
+  // 6×6 with every target = 1: a target of 1 means the cage between the two
+  // black squares sums to 1, but achieving that on every row and column
+  // simultaneously is impossible — see classify::tests::unsolvable_puzzle_*.
+  await page.goto('/?p=111111111111');
+  await waitForReady(page);
+  await expect(page.locator('[role="status"]')).toHaveText('No solution');
+});
+
+test('chip shows "Multiple solutions" for an under-constrained share URL', async ({ page }) => {
+  // 6×6 with every target = 0. The two black squares in each row/column are
+  // adjacent, but there are many ways to place them — yields multiple
+  // solutions.
+  await page.goto('/?p=000000000000');
+  await waitForReady(page);
+  await expect(page.locator('[role="status"]')).toHaveText('Multiple solutions');
+});
+
+test('chip updates when switching sizes', async ({ page }) => {
+  // Start on a multi-solution 6×6 puzzle.
+  await page.goto('/?p=000000000000');
+  await waitForReady(page);
+  await expect(page.locator('[role="status"]')).toHaveText('Multiple solutions');
+
+  // Switch to 5×5 — Play generates a fresh puzzle, which is always Normal.
+  await page.locator('.size-selector .size-btn', { hasText: '5×5' }).click();
+  await expect(page.locator('.app-shell table.puzzle th[scope="row"].target')).toHaveCount(5);
+  await expect(page.locator('[role="status"]')).toHaveText('Normal');
+
+  // Switching back to 6×6 restores the cached multi-solution puzzle, and the
+  // chip follows.
+  await page.locator('.size-selector .size-btn', { hasText: '6×6' }).click();
+  await expect(page.locator('.app-shell table.puzzle th[scope="row"].target')).toHaveCount(6);
+  await expect(page.locator('[role="status"]')).toHaveText('Multiple solutions');
+});
+
+test('chip updates after "Use this puzzle" from Create', async ({ page }) => {
+  // Default Play puzzle is unique (loadRandomPuzzle only emits propagation-
+  // solvable puzzles), so the seeded Create draft mirrors it and is also
+  // unique — letting us exercise the "Use this puzzle" path end-to-end.
+  await page.goto('/');
+  await waitForReady(page);
+  await expect(page.locator('[role="status"]')).toHaveText('Normal');
+
+  await page.locator('nav.bottom-nav').getByRole('button', { name: 'Create' }).click();
+  await expect(page.locator('.page-title')).toHaveText('Create');
+  await expect(page.locator('[role="status"]')).toHaveText('Normal');
+
+  await page.getByRole('button', { name: 'Use this puzzle' }).click();
+  await expect(page.locator('.page-title')).toHaveText('Play');
+  // The chip on Play reflects the same puzzle's classification.
+  await expect(page.locator('[role="status"]')).toHaveText('Normal');
+});


### PR DESCRIPTION
Closes #31.

## Summary

- The Play tab now classifies the active puzzle and surfaces the result as a chip in the page header, alongside the existing toast/status area. Possible labels: `Normal` / `Hard` / `Very hard` / `Extremely hard` for valid puzzles, and `No solution` / `Multiple solutions` (rendered with the error tone) for invalid ones.
- A new `web/src/state/classification.ts` module owns the `Difficulty` thresholds and `classifyCached` helper. Both `CreateTab` and `PlayTab` go through it, so labels stay consistent across the two tabs.
- Classifications are cached by puzzle targets, so re-visiting a size, switching back from Create, and re-loading the same share URL never re-runs `classify_puzzle`.

## Wiring

- `PlayTab.svelte` derives `classification` from `playState.puzzleData` via `classifyCached`. The transient `Generating…/Switching…` text and toasts still take precedence; otherwise the chip is shown.
- `CreateTab.svelte` is now a thin consumer of `classificationLabel` / `classificationTone` from the shared module — the local `difficulty` / `statusLabel` / `statusTone` helpers were dropped.

## Test plan

- [x] `npm run check` (`svelte-check`) passes.
- [x] `vite build` (test mode) succeeds.
- [x] `cargo test` passes.
- [ ] Playwright suite (`npm run test`) — couldn't run locally because the sandbox can't fetch the Chromium browser binary. The new specs in `web/tests/play-tab-chip.spec.ts` cover:
  - Generated puzzle → `Normal`.
  - `?p=111111111111` (6×6 all-1 targets, known unsolvable) → `No solution`.
  - `?p=000000000000` (6×6 all-0 targets, multi-solution) → `Multiple solutions`.
  - Switching sizes updates the chip and restores it when switching back.
  - "Use this puzzle" from Create lands on Play with the correct chip.
- [x] Existing `app-loads` "Ready status" assertion was updated to assert the new chip text instead.

I verified the chosen unsolvable / multi-solution targets against the Rust `classify::tests` (`unsolvable_puzzle_classifies_as_unsolvable` uses `[1; 6]/[1; 6]`, and the all-zero 6×6 yields `Multiple` with `search_nodes = 11`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9SNzzEP19bJhz9th8Xd8j)_