### PR TITLE
web: misc UX fixes and Issue #23 cleanups

### DIFF
--- a/web/src/components/App.svelte
+++ b/web/src/components/App.svelte
@@ -32,6 +32,14 @@
     document.documentElement.lang = currentLocale();
   });
 
+  // Scroll the tab content back to the top whenever the active tab changes
+  // — long tabs (Walkthrough, How-to) otherwise keep their scroll position
+  // when the user comes back via the bottom nav.
+  $effect(() => {
+    void tabState.active;
+    document.querySelector('.screen-content')?.scrollTo({ top: 0 });
+  });
+
   let ready = $state(false);
   let printBusy = $state(false);
 

--- a/web/src/components/PageHeader.svelte
+++ b/web/src/components/PageHeader.svelte
@@ -12,9 +12,10 @@
 
   // Map locale code → label key. Catalogs only need entries for locales they
   // know about; unknown locales fall back to upper-cased code.
-  const labelKeys: Record<string, 'loc_en' | 'loc_de' | 'loc_pt'> = {
-    en: 'loc_en',
+  const labelKeys: Record<string, 'loc_en' | 'loc_de' | 'loc_pt' | 'loc_fr'> = {
     de: 'loc_de',
+    en: 'loc_en',
+    fr: 'loc_fr',
     pt: 'loc_pt',
   };
 
@@ -88,7 +89,6 @@
       class:error={statusTone === 'error'}
       class:success={statusTone === 'success'}
       role="status"
-      aria-live="polite"
     >
       {status}
     </div>

--- a/web/src/components/PuzzleGrid.svelte
+++ b/web/src/components/PuzzleGrid.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { CellValue, CellNotes, PuzzleData, SelectedCell } from '../state/types';
   import { noteDigitBit, NOTE_BLACK_BIT, NOTE_DIGITS_ONLY_BIT } from '../state/types';
-  import { notesHaveContent } from '../state/puzzle.svelte';
+  import { cellKey, notesHaveContent } from '../state/puzzle.svelte';
 
   type CellExtras = { wrong?: boolean; exNew?: boolean };
   type TargetAxis = 'row' | 'col';
@@ -30,10 +30,6 @@
     onTargetClick,
     selectedTarget = null,
   }: Props = $props();
-
-  function cellKey(r: number, c: number): string {
-    return `${r},${c}`;
-  }
 
   function valueAt(r: number, c: number): CellValue {
     return values ? values[r][c] : null;

--- a/web/src/components/tabs/HowToTab.svelte
+++ b/web/src/components/tabs/HowToTab.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import PageHeader from '../PageHeader.svelte';
   import PuzzleGrid from '../PuzzleGrid.svelte';
+  import { emptyCellValues } from '../../state/puzzle.svelte';
   import { t, md } from '../../i18n/index.svelte';
-  import type { CellValue, PuzzleData } from '../../state/types';
+  import type { PuzzleData } from '../../state/types';
   import type { MessageKey } from '../../i18n/en';
 
   const exampleSize = 5;
@@ -11,13 +12,9 @@
     col_targets: [3, 0, 3, 0, 0],
   };
 
-  function emptyValues(): CellValue[][] {
-    return Array.from({ length: exampleSize }, () => Array<CellValue>(exampleSize).fill(null));
-  }
+  const step0Values = emptyCellValues(exampleSize);
 
-  const step0Values = emptyValues();
-
-  const step1Values = emptyValues();
+  const step1Values = emptyCellValues(exampleSize);
   step1Values[0][0] = 'black';
   step1Values[0][4] = 'black';
   const step1Extras = new Map([
@@ -25,13 +22,13 @@
     ['0,4', { exNew: true }],
   ]);
 
-  const step2Values = emptyValues();
+  const step2Values = emptyCellValues(exampleSize);
   step2Values[0][0] = 'black';
   step2Values[0][4] = 'black';
   step2Values[1][4] = 'black';
   const step2Extras = new Map([['1,4', { exNew: true }]]);
 
-  const step3Values = emptyValues();
+  const step3Values = emptyCellValues(exampleSize);
   step3Values[0][0] = 'black';
   step3Values[0][4] = 'black';
   step3Values[1][4] = 'black';

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -170,7 +170,7 @@ export const fr: Messages = {
     "Le solveur a tenté une hypothèse pour sortir d'une impasse. Rare pour les puzzles solubles à la main.",
 
   // Classification chip
-  cls_no_solution: 'Sans solution',
+  cls_no_solution: 'Aucune solution',
   cls_multiple: 'Plusieurs solutions',
   cls_normal: 'Normal',
   cls_hard: 'Difficile',

--- a/web/src/i18n/index.svelte.ts
+++ b/web/src/i18n/index.svelte.ts
@@ -5,8 +5,8 @@ import { fr } from './fr';
 
 const STORAGE_KEY = 'rublock-locale';
 
-const catalogs: Record<string, Messages> = { en, de, pt, fr };
-const AVAILABLE = Object.keys(catalogs);
+const catalogs: Record<string, Messages> = { de, en, fr, pt };
+const AVAILABLE = Object.keys(catalogs).sort();
 
 let locale = $state<string>('en');
 

--- a/web/src/state/puzzle.svelte.ts
+++ b/web/src/state/puzzle.svelte.ts
@@ -254,17 +254,6 @@ export function applyUserNote(value: CellValue | 'digits-only'): void {
   }
 }
 
-export function applyUserInput(value: CellValue | 'digits-only'): void {
-  if (!playState.selectedCell) return;
-  if (playState.inputMode === 'notes') {
-    applyUserNote(value);
-  } else if (value !== 'digits-only') {
-    // The O button is disabled in value mode, so this branch never fires for
-    // 'digits-only' in practice — guard explicitly so the types line up.
-    applyUserValue(value);
-  }
-}
-
 export function undoInput(): void {
   const op = playState.undoStack.pop();
   if (!op) return;

--- a/web/src/state/url.svelte.ts
+++ b/web/src/state/url.svelte.ts
@@ -58,7 +58,7 @@ export function parsePuzzleFromUrl(): PuzzleData | null {
 
 export function tabFromUrl(): TabName {
   const raw = new URLSearchParams(window.location.search).get('t') as TabName | null;
-  if (!raw || !VALID_TABS.has(raw) || raw === 'play') return 'play';
+  if (!raw || !VALID_TABS.has(raw)) return 'play';
   return raw;
 }
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -476,16 +476,19 @@ body {
 }
 
 /* Highlight values that lead to a uniquely-solvable puzzle for the
-   currently selected target. Other values are not disabled — the user
-   can still pick them and see the resulting status in the header. */
+   currently selected target. Uses the same accent palette as the target
+   cell's selected state in the grid, so the visual link between "the
+   target you tapped" and "the values that fit there" is obvious. Other
+   values are not disabled — the user can still pick them and see the
+   resulting status in the header. */
 .create-value-btn.valid {
-  border-color: var(--success);
-  background: color-mix(in oklab, var(--success) 14%, var(--card));
-  color: color-mix(in oklab, var(--success) 60%, var(--ink));
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-soft-ink);
 }
 
 .create-value-btn.valid:hover:not(:disabled) {
-  background: color-mix(in oklab, var(--success) 22%, var(--card));
+  background: color-mix(in oklab, var(--accent) 22%, var(--card));
 }
 
 /* ── How-to tab ── */
@@ -667,11 +670,11 @@ body {
 }
 .promo {
   display: none;
-  font-size: 0.75rem;
-  color: #666;
+  font-size: 0.95rem;
+  color: #000;
   text-align: center;
   padding-top: 0.5rem;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid #000;
   margin-top: 0.5rem;
 }
 
@@ -687,11 +690,14 @@ body {
   #print-output {
     display: block;
   }
+  /* Each page-group fills a printed page so the absolute-positioned promo
+     hugs the bottom of the page rather than the bottom of the grid. */
   .page-group {
     gap: 8mm 10mm;
     break-after: page;
     page-break-after: always;
-    padding-bottom: 12mm;
+    min-height: 95vh;
+    padding-bottom: 18mm;
   }
   .page-group:last-child {
     break-after: auto;

--- a/web/src/styles/puzzle.css
+++ b/web/src/styles/puzzle.css
@@ -239,6 +239,8 @@
 /* ── How-to example puzzles (smaller cells) ── */
 
 .howto-step {
+  display: flex;
+  justify-content: center;
   margin: 10px 0;
 }
 


### PR DESCRIPTION
## Summary

A round of small fixes across the web UI plus a few unambiguous cleanups from #23.

### UX

- **Locale switcher**: list languages alphabetically and add the missing `fr` entry to the label map — it was falling back to `"FR"` instead of `"Français"`.
- **How-to tab**: horizontally center the example grids to match the other tabs.
- **Tab change**: scroll the tab content back to the top, so the Walkthrough / How-to tabs start fresh on revisit instead of holding their old scroll position.
- **Create tab**: highlight values that yield a unique puzzle with the accent palette so the visual link to the selected target cell is obvious (was previously a green "success" tone, which read as a separate concept).
- **French catalog**: `cls_no_solution` is now "Aucune solution" — closer to "No solution" and more idiomatic than "Sans solution".

### Print view

- Drop gray accents — the footer text/border are pure black for maximum readability on photocopies.
- Slightly larger promo (`0.95rem`) and force each `.page-group` to fill the printed page (`min-height: 95vh`) so the absolute-positioned promo hugs the bottom of the page rather than trailing the puzzle grid.

### Issue #23 cleanups (the unambiguous ones)

- Drop redundant `aria-live="polite"` in `PageHeader` — `role="status"` already implies polite live-region semantics.
- Drop redundant `raw === 'play'` clause in `tabFromUrl` — the function already returns `'play'` as the default.
- Dedupe `cellKey()` — `PuzzleGrid` now imports it from `puzzle.svelte.ts` instead of redefining it locally.
- Dedupe `emptyValues()` in `HowToTab` — replaced with the existing `emptyCellValues()` from `puzzle.svelte.ts`.
- Remove the unused `applyUserInput` dispatcher; the UI already calls `applyUserValue` / `applyUserNote` directly.

The other items in #23 (route refactor, `mount()` rework, three-serializers debate, `inert` on hidden tabs, etc.) are bigger / opinionated calls and are left for a separate pass.

## Test plan

- [x] `npm run check` (svelte-check) is clean.
- [x] `npm run build` succeeds.
- [ ] Manual smoke: locale switcher shows `Deutsch · English · Français · Português` in that order; FR option label reads "Français".
- [ ] Manual smoke: open How-to and confirm the example grids are horizontally centered.
- [ ] Manual smoke: switch tabs back and forth — content starts at the top each time.
- [ ] Manual smoke: Create tab — pick a target, verify valid value buttons get the accent highlight.
- [ ] Manual smoke: Print preview a 4-page booklet — promo is black, slightly larger, and at the bottom of each page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KV17QnDNmU83eExir6Jgw2)_