### PR TITLE
Fix print view: tight gaps, black grid lines

### DIFF
--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -690,14 +690,11 @@ body {
   #print-output {
     display: block;
   }
-  /* Each page-group fills a printed page so the absolute-positioned promo
-     hugs the bottom of the page rather than the bottom of the grid. */
   .page-group {
     gap: 8mm 10mm;
     break-after: page;
     page-break-after: always;
-    min-height: 95vh;
-    padding-bottom: 18mm;
+    padding-bottom: 12mm;
   }
   .page-group:last-child {
     break-after: auto;

--- a/web/src/styles/puzzle.css
+++ b/web/src/styles/puzzle.css
@@ -266,6 +266,10 @@
     color: #000;
     background: #fff;
   }
+  .puzzle .cell {
+    border-right-color: #000;
+    border-bottom-color: #000;
+  }
   .puzzle-wrap {
     border-radius: 0;
     box-shadow: none;


### PR DESCRIPTION
## Summary

Fixes two regressions / issues in the print view.

### 1. Promo footer flowing to the next page

Last commit (957a1c5) added `min-height: 95vh` and `padding-bottom: 18mm` to `.page-group` so the absolutely-positioned promo could hug the bottom of the printed page. But `.page-group` is a CSS grid (`display: grid; grid-template-columns: repeat(2, auto)`) and grid's default `align-content` is `stretch`, so the auto rows expanded to fill the 95vh — ballooning the gaps between puzzles. With `95vh + 18mm` the page-group also exceeded the printable page height, pushing the promo to the next page.

Fix: drop `min-height: 95vh` and revert `padding-bottom` to `12mm`. The promo stays absolutely positioned and trails the grid as it did before that commit.

### 2. Grid lines gray instead of black in print

`.puzzle .cell { border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }` (specificity 0,2,0) was overriding the `.puzzle td, .puzzle th { border: 1px solid #000 }` rule (specificity 0,1,1) inside `@media print`, so cell separators stayed gray on print.

Fix: add a matching-specificity override inside `@media print` for `.puzzle .cell` to set the right/bottom border color to `#000`.

## Test plan

- [ ] Open the Print tab, generate a sheet of puzzles, and use the browser print preview.
- [ ] Verify two puzzles per row sit close together (gaps tight, controlled by `gap: 8mm 10mm`).
- [ ] Verify the promo footer stays on the same page as its puzzles for every page-group.
- [ ] Verify all grid lines are pure black, including the right and bottom borders of each cell.

https://claude.ai/code/session_01HmFLfSAj2eb92dHK2Uaoeo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmFLfSAj2eb92dHK2Uaoeo)_