### PR TITLE
walkthrough: replace assembled rule explanation with full sentences

### DIFF
--- a/web/src/components/tabs/WalkthroughTab.svelte
+++ b/web/src/components/tabs/WalkthroughTab.svelte
@@ -4,7 +4,7 @@
   import { playState } from '../../state/puzzle.svelte';
   import { explainPuzzle } from '../../wasm/api';
   import { trackEvent } from '../../analytics';
-  import { t, tf, plural, format, md } from '../../i18n/index.svelte';
+  import { t, tf, plural, md } from '../../i18n/index.svelte';
   import type { MessageKey } from '../../i18n/en';
   import type {
     CellNotes,
@@ -173,6 +173,10 @@
     Backtracking: 'wt_rule_backtrack',
   };
 
+  // Two variants per rule: the solo note (used when a wave only fires that
+  // rule) and the dominant note (used when the rule leads a mixed wave). Each
+  // string is a complete sentence, so we never assemble fragments at runtime —
+  // translators get whole sentences and don't have to fight English grammar.
   const RULE_NOTE_KEYS: Record<ExplainRule, MessageKey> = {
     TargetTuples: 'wt_rule_target_tuples_note',
     ArcConsistency: 'wt_rule_arc_note',
@@ -182,6 +186,15 @@
     Backtracking: 'wt_rule_backtrack_note',
   };
 
+  const RULE_DOMINANT_KEYS: Record<ExplainRule, MessageKey> = {
+    TargetTuples: 'wt_rule_target_tuples_dominant',
+    ArcConsistency: 'wt_rule_arc_dominant',
+    Singleton: 'wt_rule_singleton_dominant',
+    HiddenSingle: 'wt_rule_hidden_dominant',
+    BlackConsistency: 'wt_rule_black_dominant',
+    Backtracking: 'wt_rule_backtrack_dominant',
+  };
+
   function rulesHeading(counts: { rule: ExplainRule; count: number }[]): string {
     if (counts.length === 0) return '';
     return counts.map(({ rule, count }) => `${count} · ${t(RULE_LABEL_KEYS[rule])}`).join('   ');
@@ -189,12 +202,9 @@
 
   function rulesExplanation(counts: { rule: ExplainRule; count: number }[]): string {
     if (counts.length === 0) return '';
-    if (counts.length === 1) return t(RULE_NOTE_KEYS[counts[0].rule]);
-    // Several rules contributed in this wave — give the dominant rule's
-    // explanation, mentioning that others helped.
-    const [first, ...rest] = counts;
-    const others = rest.map(({ rule }) => t(RULE_LABEL_KEYS[rule]).toLowerCase()).join(', ');
-    return `${t(RULE_NOTE_KEYS[first.rule])} ${format(t('wt_extra_rules'), { others })}`;
+    const dominant = counts[0].rule;
+    const key = counts.length === 1 ? RULE_NOTE_KEYS[dominant] : RULE_DOMINANT_KEYS[dominant];
+    return t(key);
   }
 
   type Result = { ok: true; data: ExplainedPuzzle } | { ok: false; error: string } | null;

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -145,7 +145,6 @@ export const de: Messages = {
   wt_status_removed_one: '{n} Notiz entfernt',
   wt_status_removed_other: '{n} Notizen entfernt',
   wt_status_join: ' · ',
-  wt_extra_rules: 'Die Welle enthält außerdem Schlüsse aus {others}.',
 
   // Walkthrough rule labels
   wt_rule_target_tuples: 'Zielsummen',
@@ -155,7 +154,7 @@ export const de: Messages = {
   wt_rule_black: 'Zwei-Schwarze-Regel',
   wt_rule_backtrack: 'Hypothese',
 
-  // Walkthrough rule notes
+  // Walkthrough rule notes — solo: gezeigt, wenn die Welle nur diese Regel nutzt.
   wt_rule_target_tuples_note:
     'Manche Ziffern oder schwarzen Felder können in keiner Anordnung vorkommen, die den Zielwert der Zeile oder Spalte ergibt — diese werden ausgeschlossen.',
   wt_rule_arc_note:
@@ -168,6 +167,20 @@ export const de: Messages = {
     'Jede Zeile und jede Spalte hat genau zwei schwarze Felder. Diese Möglichkeiten würden ein drittes erzeugen — also fallen sie weg.',
   wt_rule_backtrack_note:
     'Der Löser hat einen Versuch gestartet, um eine Sackgasse aufzubrechen. Bei von Hand lösbaren Puzzles selten.',
+
+  // Walkthrough rule notes — dominant: gezeigt, wenn diese Regel die Welle anführt.
+  wt_rule_target_tuples_dominant:
+    'Die meisten Streichungen dieser Welle folgen aus den Zielsummen — manche Ziffern oder schwarzen Felder können in keiner Anordnung vorkommen, die den Zielwert der Zeile oder Spalte ergibt.',
+  wt_rule_arc_dominant:
+    'Die meisten Streichungen dieser Welle folgen aus dem Möglichkeitsabgleich — keine verbleibende Anordnung der Zeile oder Spalte unterstützt diese Möglichkeiten noch.',
+  wt_rule_singleton_dominant:
+    'Die meisten Streichungen dieser Welle folgen aus erzwungenen Feldern — ein nahes Feld ist jetzt eindeutig bestimmt, und sein Wert kann im Rest der Zeile oder Spalte nicht erneut auftauchen.',
+  wt_rule_hidden_dominant:
+    'Die meisten Streichungen dieser Welle folgen aus „einziger Platz" — nur ein Feld in einer Zeile oder Spalte kann eine bestimmte Ziffer oder das Schwarz noch aufnehmen, die anderen verlieren die Möglichkeit.',
+  wt_rule_black_dominant:
+    'Die meisten Streichungen dieser Welle folgen aus der Zwei-Schwarze-Regel — jede Zeile und jede Spalte hat genau zwei schwarze Felder, also fallen Möglichkeiten weg, die ein drittes erzeugen würden.',
+  wt_rule_backtrack_dominant:
+    'Die meisten Streichungen dieser Welle folgen aus Hypothesen — der Löser hat einen Versuch gestartet, um eine Sackgasse aufzubrechen. Bei von Hand lösbaren Puzzles selten.',
 
   // Classification chip
   cls_no_solution: 'Keine Lösung',

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -163,7 +163,6 @@ export const en = {
   wt_status_removed_one: '{n} note removed',
   wt_status_removed_other: '{n} notes removed',
   wt_status_join: ' · ',
-  wt_extra_rules: 'The wave also includes deductions from {others}.',
 
   // Walkthrough rule labels
   wt_rule_target_tuples: 'Target sums',
@@ -173,7 +172,7 @@ export const en = {
   wt_rule_black: 'Two-blacks rule',
   wt_rule_backtrack: 'Hypothesis',
 
-  // Walkthrough rule notes
+  // Walkthrough rule notes — solo: shown when only this rule fires in a wave.
   wt_rule_target_tuples_note:
     'Some digit or black placements simply cannot be part of any arrangement that adds up to the row or column target — those are removed.',
   wt_rule_arc_note:
@@ -186,6 +185,20 @@ export const en = {
     'Each row and each column has exactly two blacks. These options would create a third one — so they go.',
   wt_rule_backtrack_note:
     'The solver tried a guess to break a deadlock. Rare for hand-solvable puzzles.',
+
+  // Walkthrough rule notes — dominant: shown when this rule leads a mixed wave.
+  wt_rule_target_tuples_dominant:
+    'Most eliminations in this wave come from target sums — some digit or black placements simply cannot be part of any arrangement that adds up to the row or column target.',
+  wt_rule_arc_dominant:
+    'Most eliminations in this wave come from possibility checks — no remaining arrangement of the row or column still supports these options.',
+  wt_rule_singleton_dominant:
+    'Most eliminations in this wave come from forced cells — a nearby cell is now fully determined, and its value cannot repeat in the rest of its row or column.',
+  wt_rule_hidden_dominant:
+    'Most eliminations in this wave come from only-place reasoning — only one cell in a row or column can still hold a given digit or black, so the others lose it as a candidate.',
+  wt_rule_black_dominant:
+    'Most eliminations in this wave come from the two-blacks rule — each row and each column has exactly two blacks, so options that would create a third one are removed.',
+  wt_rule_backtrack_dominant:
+    'Most eliminations in this wave come from hypotheses — the solver tried guesses to break a deadlock. Rare for hand-solvable puzzles.',
 
   // Classification chip
   cls_no_solution: 'No solution',

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -60,7 +60,8 @@ export const fr: Messages = {
   print_busy: 'Génération…',
   print_btn_one: 'Générer {n} page',
   print_btn_other: 'Générer {n} pages',
-  print_footnote: 'Les tailles plus grandes et les livrets plus longs prennent un moment à générer.',
+  print_footnote:
+    'Les tailles plus grandes et les livrets plus longs prennent un moment à générer.',
 
   // Print output
   print_promo: 'Puzzles Doplo générés sur {url}',
@@ -83,7 +84,8 @@ export const fr: Messages = {
   howto_step1_heading: 'Étape 1 — La cible 6 de la ligne est la somme maximale possible',
   howto_step1_body:
     'Chiffres 1 + 2 + 3 = {*6*}. Cible 6 signifie que tous les chiffres se trouvent entre les deux cases noires, donc les cases noires vont aux extrémités : colonne 1 et colonne 5.',
-  howto_step2_heading: 'Étape 2 — La cible 0 de la colonne 5 signifie que les cases noires sont voisines',
+  howto_step2_heading:
+    'Étape 2 — La cible 0 de la colonne 5 signifie que les cases noires sont voisines',
   howto_step2_body:
     'Cible 0 signifie rien entre les cases noires — elles doivent être adjacentes. La colonne 5 a déjà une case noire en ligne 1, donc la deuxième case noire se place juste en dessous, en ligne 2.',
   howto_step3_heading: 'Étape 3 — La cible 2 de la ligne 2 fixe la deuxième case noire',
@@ -145,7 +147,6 @@ export const fr: Messages = {
   wt_status_removed_one: '{n} note supprimée',
   wt_status_removed_other: '{n} notes supprimées',
   wt_status_join: ' · ',
-  wt_extra_rules: 'La vague inclut aussi des déductions de {others}.',
 
   // Walkthrough rule labels
   wt_rule_target_tuples: 'Sommes cibles',
@@ -155,7 +156,7 @@ export const fr: Messages = {
   wt_rule_black: 'Règle des deux cases noires',
   wt_rule_backtrack: 'Hypothèse',
 
-  // Walkthrough rule notes
+  // Walkthrough rule notes — solo : affiché quand la vague n'utilise que cette règle.
   wt_rule_target_tuples_note:
     "Certains placements de chiffre ou de case noire ne peuvent faire partie d'aucun arrangement dont la somme atteint la cible de la ligne ou colonne — ceux-là sont supprimés.",
   wt_rule_arc_note:
@@ -168,6 +169,20 @@ export const fr: Messages = {
     'Chaque ligne et chaque colonne a exactement deux cases noires. Ces options créeraient une troisième — elles sont donc supprimées.',
   wt_rule_backtrack_note:
     "Le solveur a tenté une hypothèse pour sortir d'une impasse. Rare pour les puzzles solubles à la main.",
+
+  // Walkthrough rule notes — dominante : affiché quand cette règle mène une vague mixte.
+  wt_rule_target_tuples_dominant:
+    "La plupart des éliminations de cette vague viennent des sommes cibles — certains placements de chiffre ou de case noire ne peuvent faire partie d'aucun arrangement dont la somme atteint la cible de la ligne ou colonne.",
+  wt_rule_arc_dominant:
+    'La plupart des éliminations de cette vague viennent de la vérification des possibilités — aucun arrangement restant de la ligne ou colonne ne supporte encore ces options.',
+  wt_rule_singleton_dominant:
+    'La plupart des éliminations de cette vague viennent des cases forcées — une case voisine est maintenant entièrement déterminée, et sa valeur ne peut pas se répéter dans le reste de sa ligne ou colonne.',
+  wt_rule_hidden_dominant:
+    'La plupart des éliminations de cette vague viennent de la règle du seul endroit possible — une seule case d’une ligne ou colonne peut encore contenir un chiffre ou une case noire donné, donc les autres le perdent comme candidat.',
+  wt_rule_black_dominant:
+    'La plupart des éliminations de cette vague viennent de la règle des deux cases noires — chaque ligne et chaque colonne a exactement deux cases noires, donc les options qui en créeraient une troisième sont supprimées.',
+  wt_rule_backtrack_dominant:
+    "La plupart des éliminations de cette vague viennent d'hypothèses — le solveur a tenté des suppositions pour sortir d'une impasse. Rare pour les puzzles solubles à la main.",
 
   // Classification chip
   cls_no_solution: 'Aucune solution',
@@ -192,16 +207,13 @@ export const fr: Messages = {
 
   // Wasm errors
   err_row_targets_length: 'Le nombre de cibles de ligne ne correspond pas à la taille du puzzle.',
-  err_col_targets_length:
-    'Le nombre de cibles de colonne ne correspond pas à la taille du puzzle.',
-  err_targets_length_mismatch:
-    'Les cibles de ligne et de colonne doivent avoir le même nombre.',
+  err_col_targets_length: 'Le nombre de cibles de colonne ne correspond pas à la taille du puzzle.',
+  err_targets_length_mismatch: 'Les cibles de ligne et de colonne doivent avoir le même nombre.',
   err_size_range: 'La taille doit être comprise entre 5 et 8.',
   err_unsolvable: "Le puzzle n'a pas de solution.",
   err_multiple_solutions: 'Le puzzle a plusieurs solutions.',
   err_incomplete_state: 'Le solveur a renvoyé un état incomplet.',
-  err_target_out_of_range:
-    'La cible {t} est hors de portée (maximum {max} pour la taille {size}).',
+  err_target_out_of_range: 'La cible {t} est hors de portée (maximum {max} pour la taille {size}).',
 
   // Locale switcher — autonyms (language's own name); same in every catalog.
   loc_en: 'English',

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -146,7 +146,6 @@ export const pt: Messages = {
   wt_status_removed_one: '{n} nota removida',
   wt_status_removed_other: '{n} notas removidas',
   wt_status_join: ' · ',
-  wt_extra_rules: 'A onda inclui também deduções de {others}.',
 
   // Walkthrough rule labels
   wt_rule_target_tuples: 'Somas-alvo',
@@ -156,7 +155,7 @@ export const pt: Messages = {
   wt_rule_black: 'Regra dos dois pretos',
   wt_rule_backtrack: 'Hipótese',
 
-  // Walkthrough rule notes
+  // Walkthrough rule notes — solo: mostrado quando a onda usa apenas esta regra.
   wt_rule_target_tuples_note:
     'Algumas posições de dígito ou preto não podem fazer parte de qualquer arranjo que some o alvo da linha ou coluna — essas são removidas.',
   wt_rule_arc_note:
@@ -169,6 +168,20 @@ export const pt: Messages = {
     'Cada linha e cada coluna tem exatamente dois pretos. Estas opções criariam um terceiro — por isso desaparecem.',
   wt_rule_backtrack_note:
     'O solucionador testou uma hipótese para sair de um impasse. Raro em puzzles resolvíveis à mão.',
+
+  // Walkthrough rule notes — dominante: mostrado quando esta regra lidera uma onda mista.
+  wt_rule_target_tuples_dominant:
+    'A maioria das eliminações desta onda vem das somas-alvo — algumas posições de dígito ou preto não podem fazer parte de qualquer arranjo que some o alvo da linha ou coluna.',
+  wt_rule_arc_dominant:
+    'A maioria das eliminações desta onda vem da verificação de possibilidades — nenhum arranjo restante da linha ou coluna suporta ainda estas opções.',
+  wt_rule_singleton_dominant:
+    'A maioria das eliminações desta onda vem de células forçadas — uma célula próxima está agora totalmente determinada, e o seu valor não se pode repetir no resto da linha ou coluna.',
+  wt_rule_hidden_dominant:
+    'A maioria das eliminações desta onda vem da regra do único lugar — apenas uma célula de uma linha ou coluna ainda pode conter um dado dígito ou preto, por isso as outras perdem-no como candidato.',
+  wt_rule_black_dominant:
+    'A maioria das eliminações desta onda vem da regra dos dois pretos — cada linha e cada coluna tem exatamente dois pretos, por isso opções que criariam um terceiro são removidas.',
+  wt_rule_backtrack_dominant:
+    'A maioria das eliminações desta onda vem de hipóteses — o solucionador testou tentativas para sair de um impasse. Raro em puzzles resolvíveis à mão.',
 
   // Classification chip
   cls_no_solution: 'Sem solução',


### PR DESCRIPTION
## Summary

The walkthrough's "additional rules" line was built by gluing lower‑cased rule labels into a template — fine in English, but ungrammatical in German ("*Schlüsse aus einziger platz, erzwungene felder*") and tricky for any translator.

This PR keeps the existing solo per-rule note and adds a second variant per rule (`wt_rule_*_dominant`) used when a wave fires more than one rule. Each variant is a single complete sentence in each language; nothing is assembled at runtime.

- `WalkthroughTab.svelte`: `rulesExplanation` now picks the solo note when one rule fired and the dominant variant when several did. `format()` import dropped.
- All four catalogs (en/de/pt/fr): removed `wt_extra_rules`, added six `wt_rule_*_dominant` strings.

Example replacement (DE):
- Before: *"Keine verbleibende Anordnung dieser Zeile oder Spalte unterstützt diese Möglichkeiten noch — sie werden gestrichen. Die Welle enthält außerdem Schlüsse aus einziger platz, erzwungene felder."*
- After: *"Die meisten Streichungen dieser Welle folgen aus dem Möglichkeitsabgleich — keine verbleibende Anordnung der Zeile oder Spalte unterstützt diese Möglichkeiten noch."*

## Test plan
- [ ] Open the Walkthrough tab on a puzzle whose waves mix multiple rules; confirm each wave shows a single, grammatical sentence in EN/DE/PT/FR
- [ ] Open a wave that fires only one rule; confirm the original solo note still shows
- [ ] `npm run check` shows no new type errors (the two pre-existing `src/wasm/api.ts` errors about a missing `pkg/` build are unrelated)
- [ ] `npx prettier --check` passes on the touched files

https://claude.ai/code/session_01QyuMs4vUgsXttaG31AFgv1

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyuMs4vUgsXttaG31AFgv1)_