### PR TITLE
web: persist play-tab progress to localStorage (#9)

### DIFF
--- a/web/src/components/App.svelte
+++ b/web/src/components/App.svelte
@@ -9,7 +9,12 @@
   import PuzzleGrid from './PuzzleGrid.svelte';
   import { initWasm, generatePuzzle } from '../wasm/api';
   import { reportFatal } from '../error-overlay';
-  import { loadRandomPuzzle, setPuzzle } from '../state/puzzle.svelte';
+  import { loadRandomPuzzle, replacePlayPuzzle } from '../state/puzzle.svelte';
+  import {
+    applySavedStateToMemory,
+    installPersistEffect,
+    loadSavedState,
+  } from '../state/storage.svelte';
   import {
     parsePuzzleFromUrl,
     clearUrlParams,
@@ -41,25 +46,45 @@
   });
 
   let ready = $state(false);
+  let persistReady = $state(false);
   let printBusy = $state(false);
 
   type PrintGroup = { puzzles: PuzzleData[] };
   const printGroups = $state<PrintGroup[]>([]);
 
+  // Install the persistence effect during component init. It subscribes to
+  // playState/sizeStates immediately but only writes once `persistReady`
+  // flips after the boot logic in onMount has populated state.
+  installPersistEffect(() => persistReady);
+
   onMount(async () => {
+    // Boot priority for the Play tab puzzle:
+    //   1. URL `?p=` overrides only its own size; other saved sizes survive.
+    //   2. Otherwise restore from localStorage (all sizes).
+    //   3. Otherwise generate a fresh 6×6.
+    const saved = loadSavedState();
     const fromUrl = parsePuzzleFromUrl();
     try {
       await initWasm();
+
+      if (saved) applySavedStateToMemory(saved);
+
       if (fromUrl) {
-        setPuzzle(fromUrl);
-      } else {
+        // `replacePlayPuzzle` saves the previous active size into sizeStates,
+        // drops any saved progress for the URL puzzle's size, and makes the
+        // URL puzzle active.
+        replacePlayPuzzle(fromUrl);
+      } else if (!saved) {
         loadRandomPuzzle(6);
       }
+
       const t = tabFromUrl();
       if (t !== 'play') setTab(t);
 
       // Per DESIGN_NOTES.md: clear the URL param after loading — keep URL clean.
       clearUrlParams();
+
+      persistReady = true;
 
       // Pre-generate one page so Ctrl+P works immediately.
       await fillPrintOutput(6, 1);

--- a/web/src/components/tabs/PlayTab.svelte
+++ b/web/src/components/tabs/PlayTab.svelte
@@ -29,17 +29,10 @@
     classificationTone,
   } from '../../state/classification';
   import { t } from '../../i18n/index.svelte';
+  import { readHintDismissed, writeHintDismissed } from '../../state/storage';
 
   let showEmojiRain = $state(false);
-  let hintDismissed = $state<boolean>(
-    (() => {
-      try {
-        return localStorage.getItem('rublock-hint-dismissed') === '1';
-      } catch {
-        return false;
-      }
-    })()
-  );
+  let hintDismissed = $state<boolean>(readHintDismissed());
 
   let status = $state('');
 
@@ -167,9 +160,7 @@
 
   function dismissHint(): void {
     hintDismissed = true;
-    try {
-      localStorage.setItem('rublock-hint-dismissed', '1');
-    } catch {}
+    writeHintDismissed(true);
   }
 
   let cellExtras = $derived.by(() => {

--- a/web/src/i18n/index.svelte.ts
+++ b/web/src/i18n/index.svelte.ts
@@ -2,8 +2,7 @@ import { en, type MessageKey, type Messages } from './en';
 import { de } from './de';
 import { pt } from './pt';
 import { fr } from './fr';
-
-const STORAGE_KEY = 'rublock-locale';
+import { readStoredLocale, writeStoredLocale } from '../state/storage';
 
 const catalogs: Record<string, Messages> = { de, en, fr, pt };
 const AVAILABLE = Object.keys(catalogs).sort();
@@ -51,25 +50,9 @@ export function md(s: string): string {
   return esc.replace(/\{\*([^*]+)\*\}/g, '<strong>$1</strong>');
 }
 
-function readStored(): string | null {
-  try {
-    return localStorage.getItem(STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function writeStored(value: string): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, value);
-  } catch {
-    // Ignore — preference just won't persist.
-  }
-}
-
 /** Resolve locale at boot: explicit choice > browser language > 'en'. */
 export function detectLocale(): string {
-  const stored = readStored();
+  const stored = readStoredLocale();
   if (stored && stored in catalogs) return stored;
 
   // navigator.languages can be undefined in old environments / tests.
@@ -86,7 +69,7 @@ export function detectLocale(): string {
 export function setLocale(l: string): void {
   if (!(l in catalogs)) return;
   locale = l;
-  writeStored(l);
+  writeStoredLocale(l);
   if (typeof document !== 'undefined') {
     document.documentElement.lang = l;
   }

--- a/web/src/state/create.svelte.ts
+++ b/web/src/state/create.svelte.ts
@@ -25,6 +25,15 @@ export type SupportedSize = (typeof SUPPORTED_SIZES)[number];
 // goes through the proxy's setters and stays consistent across size
 // switches; storing draft objects in a separate plain Map would risk
 // drifting between the proxy's view and the cached reference.
+//
+// Note: Create-tab drafts are intentionally NOT persisted to localStorage.
+// Issue #9 scopes persistence to the Play tab's in-progress puzzle, where
+// losing partial progress is genuinely painful. A draft on this tab is just
+// a handful of target numbers — cheap to retype — and adding a second
+// storage slot or merged schema would complicate the UI without a
+// proportional benefit (the user would either need a "load from Play"
+// button or some other resolution flow for stored vs. seeded drafts).
+// Revisit if real users report losing long target sequences here.
 export const createState = $state({
   size: 6 as SupportedSize,
   drafts: {} as Partial<Record<SupportedSize, CreateDraft>>,

--- a/web/src/state/puzzle.svelte.ts
+++ b/web/src/state/puzzle.svelte.ts
@@ -78,7 +78,7 @@ export function loadRandomPuzzle(size: number): void {
   trackEvent(`rublock/play/generate/${size}`);
 }
 
-interface PerSizeState {
+export interface PerSizeState {
   puzzleData: PuzzleData;
   cellValues: CellValue[][];
   cellNotes: CellNotes[][];
@@ -89,11 +89,14 @@ interface PerSizeState {
   wrongCells: SvelteSet<string>;
 }
 
-const sizeStates = new Map<number, PerSizeState>();
+// Reactive so the persistence effect in `storage.svelte.ts` re-fires when
+// any size's state changes — including via `ensurePlayPuzzleForSize`, which
+// can populate a slot without touching `playState`.
+export const sizeStates = $state<Partial<Record<number, PerSizeState>>>({});
 
 function saveCurrentState(): void {
   if (!playState.puzzleData) return;
-  sizeStates.set(playState.puzzleData.row_targets.length, {
+  sizeStates[playState.puzzleData.row_targets.length] = {
     puzzleData: playState.puzzleData,
     cellValues: playState.cellValues.map((row) => [...row]),
     cellNotes: playState.cellNotes.map((row) => [...row]),
@@ -102,10 +105,10 @@ function saveCurrentState(): void {
     undoStack: [...playState.undoStack],
     redoStack: [...playState.redoStack],
     wrongCells: new SvelteSet(playState.wrongCells),
-  });
+  };
 }
 
-function loadSavedState(saved: PerSizeState): void {
+function applyPerSizeState(saved: PerSizeState): void {
   playState.puzzleData = saved.puzzleData;
   playState.cellValues = saved.cellValues;
   playState.cellNotes = saved.cellNotes;
@@ -122,9 +125,9 @@ export function switchToSize(size: number): void {
   if (playState.puzzleData?.row_targets.length === size) return;
   saveCurrentState();
 
-  const saved = sizeStates.get(size);
+  const saved = sizeStates[size];
   if (saved) {
-    loadSavedState(saved);
+    applyPerSizeState(saved);
   } else {
     setPuzzle(generatePuzzle(size));
     trackEvent(`rublock/play/generate/${size}`);
@@ -141,11 +144,11 @@ export function ensurePlayPuzzleForSize(size: number): PuzzleData {
   if (playState.puzzleData?.row_targets.length === size) {
     return playState.puzzleData;
   }
-  const saved = sizeStates.get(size);
+  const saved = sizeStates[size];
   if (saved) return saved.puzzleData;
   const data = generatePuzzle(size);
   trackEvent(`rublock/play/generate/${size}`);
-  const blank: PerSizeState = {
+  sizeStates[size] = {
     puzzleData: data,
     cellValues: emptyCellValues(size),
     cellNotes: emptyCellNotes(size),
@@ -155,7 +158,6 @@ export function ensurePlayPuzzleForSize(size: number): PuzzleData {
     redoStack: [],
     wrongCells: new SvelteSet(),
   };
-  sizeStates.set(size, blank);
   return data;
 }
 
@@ -168,13 +170,13 @@ export function ensurePlayPuzzleForSize(size: number): PuzzleData {
 export function replacePlayPuzzle(data: PuzzleData): void {
   const size = data.row_targets.length;
   saveCurrentState();
-  sizeStates.delete(size);
+  delete sizeStates[size];
   setPuzzle(data);
 }
 
 /** Generate a fresh puzzle for the current size, discarding any saved state. */
 export function newPuzzle(size: number): void {
-  sizeStates.delete(size);
+  delete sizeStates[size];
   setPuzzle(generatePuzzle(size));
   trackEvent(`rublock/play/generate/${size}`);
 }

--- a/web/src/state/storage.svelte.ts
+++ b/web/src/state/storage.svelte.ts
@@ -1,0 +1,373 @@
+import { SvelteSet } from 'svelte/reactivity';
+import { playState, sizeStates, type PerSizeState } from './puzzle.svelte';
+import { KEY_PLAY_STATE, safeRead, safeRemove, safeWrite } from './storage';
+import type {
+  CellNotes,
+  CellOperation,
+  CellValue,
+  InputMode,
+  PuzzleData,
+} from './types';
+
+const STORAGE_VERSION = 1;
+const DEBOUNCE_MS = 250;
+
+// ---------- Play state ----------
+
+export type SupportedSize = 5 | 6 | 7 | 8;
+
+interface SavedSizeState {
+  puzzle: PuzzleData;
+  cellValues: CellValue[][];
+  cellNotes: CellNotes[][];
+  inputMode: InputMode;
+  undoStack: CellOperation[];
+  redoStack: CellOperation[];
+  wrongCells: string[];
+}
+
+export interface SavedPlayState {
+  version: 1;
+  activeSize: SupportedSize;
+  sizes: Partial<Record<SupportedSize, SavedSizeState>>;
+}
+
+const SUPPORTED_SIZES = new Set<SupportedSize>([5, 6, 7, 8]);
+
+function isSupportedSize(n: unknown): n is SupportedSize {
+  return typeof n === 'number' && SUPPORTED_SIZES.has(n as SupportedSize);
+}
+
+function isCellValue(v: unknown, size: number): v is CellValue {
+  if (v === null) return true;
+  if (v === 'black') return true;
+  return typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= size;
+}
+
+function isCellNotes(v: unknown): v is CellNotes {
+  return typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 0xff;
+}
+
+function isInputMode(v: unknown): v is InputMode {
+  return v === 'value' || v === 'notes';
+}
+
+function validateGrid<T>(
+  raw: unknown,
+  size: number,
+  check: (v: unknown) => v is T
+): T[][] | null {
+  if (!Array.isArray(raw) || raw.length !== size) return null;
+  const rows: T[][] = [];
+  for (const row of raw) {
+    if (!Array.isArray(row) || row.length !== size) return null;
+    for (const cell of row) {
+      if (!check(cell)) return null;
+    }
+    rows.push([...row]);
+  }
+  return rows;
+}
+
+function validateOperation(raw: unknown, size: number): CellOperation | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (
+    typeof o.row !== 'number' ||
+    typeof o.col !== 'number' ||
+    !Number.isInteger(o.row) ||
+    !Number.isInteger(o.col) ||
+    o.row < 0 ||
+    o.row >= size ||
+    o.col < 0 ||
+    o.col >= size
+  ) {
+    return null;
+  }
+  if (
+    !isCellValue(o.oldValue, size) ||
+    !isCellValue(o.newValue, size) ||
+    !isCellNotes(o.oldNotes) ||
+    !isCellNotes(o.newNotes)
+  ) {
+    return null;
+  }
+  return {
+    row: o.row,
+    col: o.col,
+    oldValue: o.oldValue,
+    newValue: o.newValue,
+    oldNotes: o.oldNotes,
+    newNotes: o.newNotes,
+  };
+}
+
+function validatePuzzle(raw: unknown): { puzzle: PuzzleData; size: number } | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const p = raw as Record<string, unknown>;
+  const rt = p.row_targets;
+  const ct = p.col_targets;
+  if (!Array.isArray(rt) || !Array.isArray(ct)) return null;
+  if (rt.length !== ct.length) return null;
+  const size = rt.length;
+  if (!isSupportedSize(size)) return null;
+  for (const v of rt) {
+    if (typeof v !== 'number' || !Number.isInteger(v) || v < 0 || v > 255) return null;
+  }
+  for (const v of ct) {
+    if (typeof v !== 'number' || !Number.isInteger(v) || v < 0 || v > 255) return null;
+  }
+  return {
+    puzzle: { row_targets: [...rt], col_targets: [...ct] },
+    size,
+  };
+}
+
+function validateSize(raw: unknown): SavedSizeState | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const s = raw as Record<string, unknown>;
+
+  const puzzleResult = validatePuzzle(s.puzzle);
+  if (!puzzleResult) return null;
+  const { puzzle, size } = puzzleResult;
+
+  const cellValues = validateGrid<CellValue>(s.cellValues, size, (v): v is CellValue =>
+    isCellValue(v, size)
+  );
+  if (!cellValues) return null;
+
+  const cellNotes = validateGrid<CellNotes>(s.cellNotes, size, isCellNotes);
+  if (!cellNotes) return null;
+
+  if (!isInputMode(s.inputMode)) return null;
+
+  if (!Array.isArray(s.undoStack) || !Array.isArray(s.redoStack)) return null;
+  const undoStack: CellOperation[] = [];
+  for (const op of s.undoStack) {
+    const v = validateOperation(op, size);
+    if (!v) return null;
+    undoStack.push(v);
+  }
+  const redoStack: CellOperation[] = [];
+  for (const op of s.redoStack) {
+    const v = validateOperation(op, size);
+    if (!v) return null;
+    redoStack.push(v);
+  }
+
+  if (!Array.isArray(s.wrongCells)) return null;
+  const wrongCells: string[] = [];
+  for (const k of s.wrongCells) {
+    if (typeof k !== 'string') return null;
+    const m = /^(\d+),(\d+)$/.exec(k);
+    if (!m) return null;
+    const r = Number(m[1]);
+    const c = Number(m[2]);
+    if (r < 0 || r >= size || c < 0 || c >= size) return null;
+    wrongCells.push(k);
+  }
+
+  return { puzzle, cellValues, cellNotes, inputMode: s.inputMode, undoStack, redoStack, wrongCells };
+}
+
+function validate(raw: unknown): SavedPlayState | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (o.version !== STORAGE_VERSION) return null;
+  if (!isSupportedSize(o.activeSize)) return null;
+  if (!o.sizes || typeof o.sizes !== 'object') return null;
+  const sizes: Partial<Record<SupportedSize, SavedSizeState>> = {};
+  for (const [k, v] of Object.entries(o.sizes as Record<string, unknown>)) {
+    const sz = Number(k);
+    if (!isSupportedSize(sz)) return null;
+    const valid = validateSize(v);
+    if (!valid) return null;
+    if (valid.puzzle.row_targets.length !== sz) return null;
+    sizes[sz] = valid;
+  }
+  if (!sizes[o.activeSize]) return null;
+  return { version: 1, activeSize: o.activeSize, sizes };
+}
+
+export function loadSavedState(): SavedPlayState | null {
+  const raw = safeRead(KEY_PLAY_STATE);
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return validate(parsed);
+}
+
+function toPerSizeState(saved: SavedSizeState): PerSizeState {
+  const wrongCells = new SvelteSet<string>();
+  for (const k of saved.wrongCells) wrongCells.add(k);
+  return {
+    puzzleData: saved.puzzle,
+    cellValues: saved.cellValues.map((row) => [...row]),
+    cellNotes: saved.cellNotes.map((row) => [...row]),
+    inputMode: saved.inputMode,
+    selectedCell: null,
+    undoStack: [...saved.undoStack],
+    redoStack: [...saved.redoStack],
+    wrongCells,
+  };
+}
+
+/**
+ * Hydrate the in-memory `playState` and `sizeStates` from a saved snapshot.
+ * Run this *before* the URL `?p=` and "generate fresh" fallbacks.
+ */
+export function applySavedStateToMemory(saved: SavedPlayState): void {
+  for (const key of Object.keys(sizeStates)) {
+    delete sizeStates[Number(key) as SupportedSize];
+  }
+  for (const [k, v] of Object.entries(saved.sizes)) {
+    if (!v) continue;
+    sizeStates[Number(k) as SupportedSize] = toPerSizeState(v);
+  }
+  const active = sizeStates[saved.activeSize]!;
+  playState.puzzleData = active.puzzleData;
+  playState.cellValues = active.cellValues.map((row) => [...row]);
+  playState.cellNotes = active.cellNotes.map((row) => [...row]);
+  playState.inputMode = active.inputMode;
+  playState.selectedCell = null;
+  playState.undoStack = [...active.undoStack];
+  playState.redoStack = [...active.redoStack];
+  playState.wrongCells.clear();
+  for (const k of active.wrongCells) playState.wrongCells.add(k);
+}
+
+function snapshotActiveSize(): SavedSizeState | null {
+  if (!playState.puzzleData) return null;
+  return {
+    puzzle: {
+      row_targets: [...playState.puzzleData.row_targets],
+      col_targets: [...playState.puzzleData.col_targets],
+    },
+    cellValues: playState.cellValues.map((row) => [...row]),
+    cellNotes: playState.cellNotes.map((row) => [...row]),
+    inputMode: playState.inputMode,
+    undoStack: playState.undoStack.map((op) => ({ ...op })),
+    redoStack: playState.redoStack.map((op) => ({ ...op })),
+    wrongCells: [...playState.wrongCells],
+  };
+}
+
+function snapshotSizeState(s: PerSizeState): SavedSizeState {
+  return {
+    puzzle: {
+      row_targets: [...s.puzzleData.row_targets],
+      col_targets: [...s.puzzleData.col_targets],
+    },
+    cellValues: s.cellValues.map((row) => [...row]),
+    cellNotes: s.cellNotes.map((row) => [...row]),
+    inputMode: s.inputMode,
+    undoStack: s.undoStack.map((op) => ({ ...op })),
+    redoStack: s.redoStack.map((op) => ({ ...op })),
+    wrongCells: [...s.wrongCells],
+  };
+}
+
+function serializeAll(): string | null {
+  const active = snapshotActiveSize();
+  if (!active) return null;
+  const activeSize = active.puzzle.row_targets.length as SupportedSize;
+  if (!isSupportedSize(activeSize)) return null;
+
+  const sizes: Partial<Record<SupportedSize, SavedSizeState>> = {};
+  for (const [k, v] of Object.entries(sizeStates)) {
+    if (!v) continue;
+    const sz = Number(k);
+    if (!isSupportedSize(sz)) continue;
+    sizes[sz] = snapshotSizeState(v);
+  }
+  // The active size may not be in `sizeStates` yet (it's only persisted
+  // there on a size switch). Always write the live `playState` snapshot.
+  sizes[activeSize] = active;
+
+  const payload: SavedPlayState = { version: 1, activeSize, sizes };
+  return JSON.stringify(payload);
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flushSaveNow(): void {
+  if (saveTimer !== null) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  const json = serializeAll();
+  if (json === null) return;
+  safeWrite(KEY_PLAY_STATE, json);
+}
+
+function scheduleSave(): void {
+  if (saveTimer !== null) clearTimeout(saveTimer);
+  saveTimer = setTimeout(flushSaveNow, DEBOUNCE_MS);
+}
+
+/**
+ * Wire up a Svelte 5 `$effect` that watches `playState` + `sizeStates` and
+ * writes the merged snapshot to localStorage on every change (debounced).
+ *
+ * Must be called synchronously from a component's `<script>` body — Svelte 5
+ * forbids `$effect` outside component initialization. The `isReady` callback
+ * gates writes until the host component has finished its boot logic; before
+ * that, the effect just subscribes to deps without touching storage.
+ */
+export function installPersistEffect(isReady: () => boolean): void {
+  $effect(() => {
+    // Touch every reactive dep so deep mutations re-run the effect. Svelte 5
+    // $state proxies arrays at every depth, so reading individual cells is
+    // enough to subscribe to per-cell mutations.
+    const pd = playState.puzzleData;
+    if (pd) {
+      void pd.row_targets.length;
+      void pd.col_targets.length;
+    }
+    void playState.inputMode;
+    void playState.undoStack.length;
+    void playState.redoStack.length;
+    void playState.wrongCells.size;
+    for (let r = 0; r < playState.cellValues.length; r++) {
+      const row = playState.cellValues[r];
+      for (let c = 0; c < row.length; c++) void row[c];
+    }
+    for (let r = 0; r < playState.cellNotes.length; r++) {
+      const row = playState.cellNotes[r];
+      for (let c = 0; c < row.length; c++) void row[c];
+    }
+
+    for (const key of Object.keys(sizeStates)) {
+      const s = sizeStates[Number(key) as SupportedSize];
+      if (!s) continue;
+      void s.inputMode;
+      void s.undoStack.length;
+      void s.redoStack.length;
+      void s.wrongCells.size;
+      for (let r = 0; r < s.cellValues.length; r++) {
+        const row = s.cellValues[r];
+        for (let c = 0; c < row.length; c++) void row[c];
+      }
+      for (let r = 0; r < s.cellNotes.length; r++) {
+        const row = s.cellNotes[r];
+        for (let c = 0; c < row.length; c++) void row[c];
+      }
+    }
+
+    if (!isReady()) return;
+    scheduleSave();
+  });
+}
+
+/** Forget any saved play state. Exposed for tests / explicit reset. */
+export function clearSavedState(): void {
+  if (saveTimer !== null) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  safeRemove(KEY_PLAY_STATE);
+}

--- a/web/src/state/storage.ts
+++ b/web/src/state/storage.ts
@@ -1,0 +1,73 @@
+// Centralised localStorage access for the entire app.
+//
+// Anything in the codebase that touches `localStorage` should go through this
+// module so that:
+//   * key naming stays consistent (`rublock-<feature>`),
+//   * IO failures (private mode, quota exceeded, disabled cookies) degrade
+//     silently and consistently,
+//   * a single grep finds every persisted key.
+//
+// The play-state slot is large/structured and lives in `storage.svelte.ts`
+// alongside the persistence effect; this file holds the small primitive
+// keys plus the shared safe-IO helpers.
+
+export const KEY_PLAY_STATE = 'rublock-play-state';
+export const KEY_LOCALE = 'rublock-locale';
+export const KEY_HINT_DISMISSED = 'rublock-hint-dismissed';
+
+let writesDisabled = false;
+let warnedOnce = false;
+
+function warnOnce(err: unknown): void {
+  if (warnedOnce) return;
+  warnedOnce = true;
+  console.warn('rublock storage unavailable:', err);
+}
+
+export function safeRead(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch (err) {
+    warnOnce(err);
+    return null;
+  }
+}
+
+export function safeWrite(key: string, value: string): void {
+  if (writesDisabled) return;
+  try {
+    localStorage.setItem(key, value);
+  } catch (err) {
+    writesDisabled = true;
+    warnOnce(err);
+  }
+}
+
+export function safeRemove(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // Nothing useful we can do.
+  }
+}
+
+// ---------- Locale ----------
+
+export function readStoredLocale(): string | null {
+  return safeRead(KEY_LOCALE);
+}
+
+export function writeStoredLocale(value: string): void {
+  safeWrite(KEY_LOCALE, value);
+}
+
+// ---------- Hint banner ----------
+
+export function readHintDismissed(): boolean {
+  return safeRead(KEY_HINT_DISMISSED) === '1';
+}
+
+export function writeHintDismissed(value: boolean): void {
+  if (value) safeWrite(KEY_HINT_DISMISSED, '1');
+  else safeRemove(KEY_HINT_DISMISSED);
+}

--- a/web/tests/play-persistence.spec.ts
+++ b/web/tests/play-persistence.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const STORAGE_KEY = 'rublock-play-state';
+
+async function waitForReady(page: Page) {
+  await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
+}
+
+function firstDataCell(page: Page) {
+  return page.locator('.app-shell table.puzzle tbody tr:first-child td:nth-child(2)');
+}
+
+function rowTargetCells(page: Page) {
+  return page.locator('.app-shell table.puzzle th[scope="row"].target');
+}
+
+async function readStoredState(page: Page): Promise<unknown | null> {
+  return page.evaluate((key) => {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  }, STORAGE_KEY);
+}
+
+// Wait long enough for the 250 ms persistence debounce to flush.
+async function waitForDebounce(page: Page) {
+  await page.waitForTimeout(350);
+}
+
+// Each test gets a fresh BrowserContext from Playwright, so localStorage
+// starts empty. The seed-localStorage helpers below run BEFORE every page
+// load in the test, which is fine for tests that only navigate once.
+
+test('a placed value survives a full page reload', async ({ page }) => {
+  // Use a deterministic puzzle so the targets render predictably after reload.
+  await page.goto('/?p=5,10,15,20,25,3,6,9,12,15');
+  await waitForReady(page);
+
+  const cell = firstDataCell(page);
+  await cell.click();
+  await page.keyboard.press('1');
+  await expect(cell.locator('.cell-value')).toHaveText('1');
+
+  await waitForDebounce(page);
+
+  // Plain reload (no `?p=`) — localStorage must take over.
+  await page.goto('/');
+  await waitForReady(page);
+
+  // Same puzzle (5×5 from the URL above) is restored along with the digit.
+  await expect(rowTargetCells(page)).toHaveText(['5', '10', '15', '20', '25']);
+  await expect(firstDataCell(page).locator('.cell-value')).toHaveText('1');
+});
+
+test('?p= takes precedence over saved state for the same size', async ({ page }) => {
+  // First visit: save progress for one 5×5 puzzle.
+  await page.goto('/?p=5,10,15,20,25,3,6,9,12,15');
+  await waitForReady(page);
+  await firstDataCell(page).click();
+  await page.keyboard.press('1');
+  await expect(firstDataCell(page).locator('.cell-value')).toHaveText('1');
+  await waitForDebounce(page);
+
+  // Second visit with a *different* 5×5 puzzle — URL wins; previous progress
+  // for that size is discarded.
+  await page.goto('/?p=2,4,6,8,10,1,3,5,7,9');
+  await waitForReady(page);
+
+  await expect(rowTargetCells(page)).toHaveText(['2', '4', '6', '8', '10']);
+  // The previously placed value is gone for the new puzzle.
+  await expect(firstDataCell(page).locator('.cell-value')).not.toBeVisible();
+});
+
+test('?p= for one size leaves saved progress on other sizes intact', async ({ page }) => {
+  // Save progress on a 5×5 puzzle.
+  await page.goto('/?p=5,10,15,20,25,3,6,9,12,15');
+  await waitForReady(page);
+  await firstDataCell(page).click();
+  await page.keyboard.press('1');
+  await expect(firstDataCell(page).locator('.cell-value')).toHaveText('1');
+  await waitForDebounce(page);
+
+  // Open with a *different size* — overrides only the 7×7 slot.
+  // 14 base62 chars → size 7. Targets here are arbitrary; we only need a
+  // valid 7×7 grid to render so we can switch back to 5×5.
+  await page.goto('/?p=11111114444444');
+  await waitForReady(page);
+  // The 7×7 puzzle is now active.
+  await expect(rowTargetCells(page)).toHaveCount(7);
+  await waitForDebounce(page);
+
+  // Switch back to 5×5 — saved progress (the '1' in the first cell) survives.
+  await page.locator('.size-selector .size-btn', { hasText: '5×5' }).click();
+  await expect(rowTargetCells(page)).toHaveText(['5', '10', '15', '20', '25']);
+  await expect(firstDataCell(page).locator('.cell-value')).toHaveText('1');
+});
+
+test('no URL and empty storage falls back to a random 6×6 puzzle', async ({ page }) => {
+  await page.goto('/');
+  await waitForReady(page);
+
+  await expect(page.locator('.size-selector .size-btn.active')).toHaveText('6×6');
+  await expect(rowTargetCells(page)).toHaveCount(6);
+});
+
+test('malformed saved state is ignored silently', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('rublock-play-state', 'not valid json');
+  });
+
+  await page.goto('/');
+  await waitForReady(page);
+
+  // App must boot normally with a default 6×6 puzzle rather than crashing.
+  await expect(page.locator('.size-selector .size-btn.active')).toHaveText('6×6');
+  await expect(rowTargetCells(page)).toHaveCount(6);
+});
+
+test('a saved state with an unknown future version is ignored', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'rublock-play-state',
+      JSON.stringify({ version: 99, activeSize: 6, sizes: {} })
+    );
+  });
+
+  await page.goto('/');
+  await waitForReady(page);
+  await expect(page.locator('.size-selector .size-btn.active')).toHaveText('6×6');
+  await expect(rowTargetCells(page)).toHaveCount(6);
+});
+
+test('persisted blob is versioned and includes the active size', async ({ page }) => {
+  await page.goto('/?p=5,10,15,20,25,3,6,9,12,15');
+  await waitForReady(page);
+
+  await firstDataCell(page).click();
+  await page.keyboard.press('1');
+  await waitForDebounce(page);
+
+  const stored = (await readStoredState(page)) as {
+    version: number;
+    activeSize: number;
+    sizes: Record<string, { puzzle: { row_targets: number[] }; undoStack: unknown[] }>;
+  } | null;
+  expect(stored).not.toBeNull();
+  expect(stored!.version).toBe(1);
+  expect(stored!.activeSize).toBe(5);
+  expect(stored!.sizes['5'].puzzle.row_targets).toEqual([5, 10, 15, 20, 25]);
+  // The digit press generates one undo entry.
+  expect(stored!.sizes['5'].undoStack.length).toBeGreaterThanOrEqual(1);
+});
+
+test('locale preference still round-trips after the storage refactor', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('rublock-locale', 'de');
+  });
+
+  await page.goto('/');
+  await waitForReady(page);
+
+  // German UI: bottom-nav "Play" reads "Spielen".
+  await expect(page.locator('nav.bottom-nav button.active')).toContainText('Spielen');
+});
+
+test('hint-dismissed flag still round-trips after the storage refactor', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('rublock-hint-dismissed', '1');
+  });
+
+  await page.goto('/');
+  await waitForReady(page);
+
+  // The dismissible hint chip is hidden.
+  await expect(page.locator('.hint-chip')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

Closes #9.

- Save the active puzzle plus per-size progress to a single `localStorage` slot (`rublock-play-state`) so users don't lose their work when the tab closes or the page reloads.
- Boot priority is **URL `?p=` → localStorage → generate**. A URL puzzle only overrides the slot for *its own size*, preserving saved progress on the other sizes (per the user-clarified scope discussion in the issue).
- Consolidate every existing `localStorage` call site into a new `web/src/state/storage.ts` (+ `storage.svelte.ts` for the play-state effect) so all keys share one safe-IO wrapper and the `rublock-<feature>` naming convention. The previously inline IO for `rublock-locale` and `rublock-hint-dismissed` now goes through the same helpers.

## Design notes

- **Schema**: versioned (`version: 1`) JSON payload with `activeSize` and a `sizes: { 5|6|7|8: SavedSizeState }` map. Validation silently returns `null` on any shape error or unknown version, so corrupt or future-version slots are simply ignored.
- **Persistence effect**: Svelte 5 `$effect` installed at component init in `App.svelte`, gated by a `persistReady` flag so writes don't fire during boot. Mutations are debounced 250 ms.
- **Reactivity**: `sizeStates` in `puzzle.svelte.ts` was a plain `Map`; converted to a `$state` object so `ensurePlayPuzzleForSize` (called from the Create tab) re-fires the persistence effect even when it doesn't touch `playState`.
- **Create tab is intentionally not persisted**. The decision and reasoning are documented in `create.svelte.ts` so the choice isn't lost — re-typing target numbers is much cheaper than losing a half-solved puzzle, and adding a second slot/schema would force a new "load from Play" UI affordance for marginal benefit.
- **No timer field** in the saved blob: the issue's stored shape mentioned `timer: { elapsedMs, lastTickAt }`, but no timer feature exists in the current code. When one lands, bump to `version: 2` and migrate.

## Test plan

New Playwright suite at `web/tests/play-persistence.spec.ts`:

- [ ] A placed value survives a full reload.
- [ ] `?p=` overrides saved state for the same size (URL wins).
- [ ] `?p=` for one size leaves saved progress on other sizes intact (verified by switching back via the size selector).
- [ ] No URL and empty storage falls back to a random 6×6 puzzle.
- [ ] Malformed saved state (`'not valid json'`) is ignored silently and the app still boots.
- [ ] An unknown future `version` is ignored and the app still boots.
- [ ] The persisted blob shape is versioned and contains the active size.
- [ ] `rublock-locale` still round-trips after the storage refactor (German UI loads).
- [ ] `rublock-hint-dismissed` still round-trips (hint chip stays hidden).

Type check (`npm run check`) and `build:test` both pass locally; full Playwright run will be exercised by CI.

https://claude.ai/code/session_014wXmq9McPMBpRrdcRqGZmd

---
_Generated by [Claude Code](https://claude.ai/code/session_014wXmq9McPMBpRrdcRqGZmd)_