### PR TITLE
web: add post-solve EthicalAds slot

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,32 @@
+# Privacy
+
+Rublock is a Doplo puzzle that runs entirely in your browser. The
+puzzle solver is compiled to WebAssembly; nothing about the puzzle you
+are playing leaves your device.
+
+## What we store locally
+
+Your in-progress puzzle, settings, and dismissed hints are saved to
+`localStorage` so the puzzle survives a refresh or a new browser tab.
+This data is on your device only; clearing your browser storage erases
+it.
+
+## Analytics
+
+In production we count page views with
+[GoatCounter](https://www.goatcounter.com/), a privacy-respecting
+analytics service that does not use cookies or fingerprinting and
+records aggregate counts rather than per-user trails.
+
+## Ads
+
+After you solve a puzzle we show a single ad served by
+[EthicalAds](https://www.ethicalads.io/). EthicalAds does not use
+cookies, does not fingerprint your device, and only records aggregate
+impression counts. Their
+[privacy policy](https://www.ethicalads.io/privacy-policy/) has the
+full details.
+
+## Questions
+
+Open an issue at <https://github.com/Sjlver/rublock>.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ mise run fmt        # cargo fmt + prettier — good as a pre-commit step
 ```
 
 If you'd rather drive npm directly: build the wasm, copy `pkg/rublock_bg.wasm` and `pkg/rublock.js` into `web/src/wasm/pkg/`, then run `npm install && npm run build` in `web/`. The full sequence is in `.github/workflows/deploy.yml`.
+
+## Funding
+
+Rublock shows a single privacy-respecting ad after each solved puzzle, served by [EthicalAds](https://www.ethicalads.io/) — no cookies, no fingerprinting, no third-party trackers. The ad is gated behind the build-time env var `VITE_ETHICALADS_PUBLISHER_ID`; if unset, no ad container or loader script ships. See [`PRIVACY.md`](./PRIVACY.md) for the full data story.

--- a/web/src/components/AdSlot.svelte
+++ b/web/src/components/AdSlot.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  // Build-time publisher id; unset → AdSlot renders nothing (ships safely
+  // before EthicalAds approval). The MODE check mirrors `analytics.ts`
+  // and the inject-goatcounter plugin: only `--mode production` enables.
+  const PUBLISHER_ID = import.meta.env.VITE_ETHICALADS_PUBLISHER_ID as string | undefined;
+  const ENABLED = import.meta.env.MODE === 'production' && !!PUBLISHER_ID;
+
+  let mounted = $state(false);
+
+  onMount(() => {
+    if (!ENABLED) return;
+    // Idempotent: the SPA mounts AdSlot once per solve, but the EthicalAds
+    // client script only needs to load once across the session.
+    if (!document.querySelector('script[data-ea-script]')) {
+      const s = document.createElement('script');
+      s.src = 'https://media.ethicalads.io/media/client/ethicalads.min.js';
+      s.async = true;
+      s.dataset.eaScript = '1';
+      document.head.appendChild(s);
+    }
+    mounted = true;
+  });
+</script>
+
+{#if ENABLED && mounted}
+  <aside
+    class="ad-slot"
+    data-ad-slot
+    data-ea-publisher={PUBLISHER_ID}
+    data-ea-type="image"
+    data-ea-keywords="puzzle|games|logic"
+    data-ea-style="stickybox"
+    aria-label="Advertisement"
+  ></aside>
+{/if}
+
+<style>
+  .ad-slot {
+    display: block;
+    margin: 1.25rem auto 0;
+    max-width: 360px;
+    /* Reserve vertical space so the ad doesn't cause CLS when it loads. */
+    min-height: 100px;
+  }
+</style>

--- a/web/src/components/tabs/PlayTab.svelte
+++ b/web/src/components/tabs/PlayTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import AdSlot from '../AdSlot.svelte';
   import PuzzleGrid from '../PuzzleGrid.svelte';
   import InputBar from '../InputBar.svelte';
   import EmojiRain from '../EmojiRain.svelte';
@@ -37,6 +38,9 @@
   import { isSupportedSize } from '../../state/storage.svelte';
 
   let showEmojiRain = $state(false);
+  // Latches on solve and resets on new puzzle / size switch. Drives the
+  // post-solve AdSlot, which needs to persist past the 5s emoji rain.
+  let solvedThisGame = $state(false);
   let hintDismissed = $state<boolean>(readHintDismissed());
 
   let status = $state('');
@@ -61,6 +65,7 @@
     const offSolved = onSolved(() => {
       showEmojiRain = false;
       queueMicrotask(() => (showEmojiRain = true));
+      solvedThisGame = true;
     });
     const onKey = (event: KeyboardEvent) => {
       closeMenuOnEscape(event);
@@ -156,6 +161,7 @@
   function handleSizeClick(s: number): void {
     status = t('play_status_switching');
     switchToSize(s);
+    solvedThisGame = false;
     status = '';
   }
 
@@ -164,6 +170,7 @@
     status = t('play_status_generating');
     queueMicrotask(() => {
       newPuzzle(playState.puzzleData!.row_targets.length);
+      solvedThisGame = false;
       status = '';
     });
   }
@@ -183,6 +190,7 @@
     queueMicrotask(() => {
       try {
         newPuzzleWithDifficulty(size, d);
+        solvedThisGame = false;
       } finally {
         status = '';
       }
@@ -464,6 +472,10 @@
       onPlaceValue={(v) => applyUserValue(v)}
       onErase={() => applyUserNote(null)}
     />
+  {/if}
+
+  {#if solvedThisGame}
+    <AdSlot />
   {/if}
 </div>
 

--- a/web/tests/ad-slot.spec.ts
+++ b/web/tests/ad-slot.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// Playwright runs against `build:test`, which uses `--mode test`. AdSlot
+// renders nothing outside of `--mode production`, and no EthicalAds
+// publisher id is wired in test builds. The slot and its loader script
+// must both be absent from the DOM in this mode.
+//
+// Production verification (slot renders, script loads, ad fills) happens
+// manually post-deploy once the EthicalAds publisher application is
+// approved and VITE_ETHICALADS_PUBLISHER_ID is set in the deploy workflow.
+
+test('ad slot is not present on a fresh load in test-mode builds', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
+
+  await expect(page.locator('[data-ad-slot]')).toHaveCount(0);
+  await expect(page.locator('script[data-ea-script]')).toHaveCount(0);
+});
+
+test('ad slot stays absent even after solving in test-mode builds', async ({ page }) => {
+  // Reuses the known-solvable puzzle and hand-checked solution from
+  // cell-interactions.spec.ts. The PlayTab `solvedThisGame` latch flips
+  // here, but AdSlot's MODE gate must keep the slot out of the DOM.
+  await page.goto('/?p=7047430a4100');
+  await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
+
+  const solution: string[][] = [
+    ['3', 'black', '1', '2', '4', 'black'],
+    ['4', '1', '2', '3', 'black', 'black'],
+    ['1', '2', 'black', '4', 'black', '3'],
+    ['black', '3', '4', 'black', '2', '1'],
+    ['black', '4', 'black', '1', '3', '2'],
+    ['2', 'black', '3', 'black', '1', '4'],
+  ];
+  const rows = page.locator('.app-shell table.puzzle tbody tr');
+  for (let r = 0; r < 6; r++) {
+    for (let c = 0; c < 6; c++) {
+      await rows.nth(r).locator('td').nth(c).click();
+      await page.keyboard.press(solution[r][c] === 'black' ? 'b' : solution[r][c]);
+    }
+  }
+
+  // Solve toast confirms the solved-event fired (and the latch flipped).
+  await expect(page.locator('[role="status"]')).toContainText('Puzzle solved!');
+  await expect(page.locator('[data-ad-slot]')).toHaveCount(0);
+  await expect(page.locator('script[data-ea-script]')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

- New `<AdSlot>` Svelte 5 component that renders an EthicalAds container after a puzzle is solved. Lazy-loads the EthicalAds loader script on first mount.
- Gate: AdSlot only renders when `MODE === 'production'` **and** `VITE_ETHICALADS_PUBLISHER_ID` is set at build time. Mirrors the GoatCounter pattern in `web/src/analytics.ts` and the `inject-goatcounter` Vite plugin. With no env var set, ad-related code dead-code-eliminates from the bundle (verified by grepping the test build for `ethicalads`/`data-ea`/`data-ad-slot` — all zero hits).
- New `solvedThisGame` latch in `PlayTab.svelte` drives the slot. The existing `showEmojiRain` only lives for 5s; the latch resets on `New puzzle`, size switch, and difficulty-pick.
- `tests/ad-slot.spec.ts`: two cases (fresh load, after solving a known puzzle) — both assert the slot and loader script are absent in `--mode test` builds.
- `PRIVACY.md` (new) covers local storage, GoatCounter analytics, and EthicalAds.
- `README.md` gains a short "Funding" section describing the slot and the env-var switch.

This PR ships from the netpositive project's W21 plan ([context](https://github.com/Sjlver/netpositive/blob/main/check-ins/2026-W21.md) — not public, see `notes/rublock-scoping.md` for the design memo). It's the cheap experiment that decides whether to invest in a Path-B Android wrap with AdMob.

## What's not in this PR (intentionally)

- **No publisher ID is set.** The slot stays a no-op until the EthicalAds publisher application is approved and the deploy workflow sets `VITE_ETHICALADS_PUBLISHER_ID`. The owner controls when ads go live by setting that env var, not by merging this PR.
- **No CSP changes.** GitHub Pages doesn't enforce a CSP and the repo doesn't ship a meta-CSP, so there's nothing to update.
- **No service-worker bump.** There's no service worker in this repo.

## Test plan

- [x] `npm run check` (svelte-check) — 114 files, 0 errors, 0 warnings
- [x] `npm run build:test` — succeeds; grep of the resulting bundle for `ethicalads`/`data-ea`/`data-ad-slot` returns zero hits (gate works at build time)
- [x] `mise run test-web` — all 49 Playwright tests pass locally (Chromium), including the two new `ad-slot.spec.ts` cases
- [ ] CI Playwright run on this PR
- [ ] (post-merge) Owner applies to EthicalAds, gets publisher ID, sets `VITE_ETHICALADS_PUBLISHER_ID` in `.github/workflows/deploy.yml`, redeploys. Verify the slot renders post-solve in production.

## Notes for the reviewer

- The Vite plugin in `vite.config.ts` injects GoatCounter via HTML; this PR loads EthicalAds via runtime `onMount` instead because the component-local lifecycle is the cleanest place to gate on solve. Happy to refactor to a Vite plugin if you'd prefer the symmetric pattern.
- `data-ea-keywords` is set to `puzzle|games|logic` — feel free to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)