### PR TITLE
web: post-solve "support the project" card (Liberapay / Ko-fi)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,32 @@
+# Privacy
+
+Rublock is a Doplo puzzle that runs entirely in your browser. The puzzle
+solver is compiled to WebAssembly; nothing about the puzzle you are playing
+leaves your device.
+
+## What we store locally
+
+Your in-progress puzzle, settings, dismissed hints, and a count of how many
+puzzles you have solved are saved to `localStorage` so they survive a refresh
+or a new browser tab. This data stays on your device; clearing your browser
+storage erases it.
+
+## Analytics
+
+In production we count page views and a few anonymous events — for example,
+how often the support card below is shown and clicked — with
+[GoatCounter](https://www.goatcounter.com/), a privacy-respecting analytics
+service that does not use cookies or fingerprinting and records aggregate
+counts rather than per-user trails.
+
+## Supporting the project
+
+Rublock is free and shows no ads. Once in a while, after you solve a puzzle, a
+small card invites you to support development on
+[Liberapay](https://liberapay.com/) or [Ko-fi](https://ko-fi.com/). Following
+one of those links takes you to that platform, whose own privacy policy then
+applies. We don't embed their scripts or trackers — the card is just a link.
+
+## Questions
+
+Open an issue at <https://github.com/Sjlver/rublock>.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ mise run fmt        # cargo fmt + prettier — good as a pre-commit step
 ```
 
 If you'd rather drive npm directly: build the wasm, copy `pkg/rublock_bg.wasm` and `pkg/rublock.js` into `web/src/wasm/pkg/`, then run `npm install && npm run build` in `web/`. The full sequence is in `.github/workflows/deploy.yml`.
+
+## Funding
+
+rublock is free and ad-free. Once in a while — after a _prime-numbered_ solve (your 2nd, 3rd, 5th, 7th… puzzle, so it starts occasional and grows rarer) — a small card invites you to support development on [Liberapay](https://liberapay.com/Sjlver/) or Ko-fi. It's a plain link: no third-party ad scripts and no trackers. See [`PRIVACY.md`](./PRIVACY.md) for the full data story.

--- a/web/src/components/SupportCard.svelte
+++ b/web/src/components/SupportCard.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { t, tf } from '../i18n/index.svelte';
+  import { trackSupportImpression, trackSupportClick, type SupportPrompt } from '../state/support';
+
+  interface Props {
+    prompt: SupportPrompt;
+    onDismiss: () => void;
+  }
+
+  let { prompt, onDismiss }: Props = $props();
+
+  // The card is only mounted when PlayTab decides to show it (a prime-numbered
+  // solve), so mounting == one impression. `{#key prompt}` in the parent gives
+  // each new prompt a fresh mount, so a re-solve fires a fresh impression.
+  onMount(() => trackSupportImpression(prompt));
+
+  function handleClick(): void {
+    // Fire-and-forget; don't preventDefault, so the link still navigates.
+    trackSupportClick(prompt);
+  }
+</script>
+
+<aside
+  class="support-card card"
+  data-support-card
+  data-support-platform={prompt.platform.id}
+  data-support-copy={prompt.copyIndex}
+>
+  <button
+    type="button"
+    class="support-dismiss"
+    onclick={onDismiss}
+    aria-label={t('support_dismiss_aria')}
+  >
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+    >
+      <path d="M6 6l12 12M18 6L6 18" />
+    </svg>
+  </button>
+
+  <p class="support-copy">{t(prompt.copyKey)}</p>
+
+  <a
+    class="btn-primary support-link"
+    href={prompt.platform.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    onclick={handleClick}
+  >
+    <!-- Heart icon -->
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path
+        d="M12 21s-6.7-4.35-9.33-8.07C1.3 10.7 1.6 7.6 3.9 6.05c1.86-1.26 4.3-.77 5.6.94L12 10l2.5-3.01c1.3-1.71 3.74-2.2 5.6-.94 2.3 1.55 2.6 4.65.93 6.88C18.7 16.65 12 21 12 21z"
+      />
+    </svg>
+    {tf('support_button', { platform: prompt.platform.label })}
+  </a>
+</aside>
+
+<style>
+  .support-card {
+    position: relative;
+    margin: 1.25rem auto 0;
+    max-width: 360px;
+    text-align: center;
+    /* Reserve space so the card appearing doesn't shift surrounding layout. */
+    min-height: 96px;
+  }
+  .support-copy {
+    font-size: 13.5px;
+    line-height: 1.45;
+    color: var(--ink-2);
+    /* Leave room on the right so long copy never collides with the dismiss X. */
+    margin: 2px 20px 12px;
+  }
+  .support-link {
+    text-decoration: none;
+  }
+  .support-dismiss {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    border: none;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    font-family: inherit;
+  }
+  .support-dismiss:hover {
+    color: var(--ink);
+  }
+</style>

--- a/web/src/components/tabs/PlayTab.svelte
+++ b/web/src/components/tabs/PlayTab.svelte
@@ -3,6 +3,7 @@
   import PuzzleGrid from '../PuzzleGrid.svelte';
   import InputBar from '../InputBar.svelte';
   import EmojiRain from '../EmojiRain.svelte';
+  import SupportCard from '../SupportCard.svelte';
   import PageHeader from '../PageHeader.svelte';
   import {
     playState,
@@ -35,8 +36,13 @@
   import { t } from '../../i18n/index.svelte';
   import { readHintDismissed, writeHintDismissed } from '../../state/storage';
   import { isSupportedSize } from '../../state/storage.svelte';
+  import { isPrime, recordSolve, nextSupportPrompt, type SupportPrompt } from '../../state/support';
 
   let showEmojiRain = $state(false);
+  // Post-solve "support the project" CTA. Set to a prompt only on a
+  // prime-numbered solve (see state/support.ts), and reset whenever a fresh
+  // puzzle starts so the card belongs to exactly one solved board.
+  let supportPrompt = $state<SupportPrompt | null>(null);
   let hintDismissed = $state<boolean>(readHintDismissed());
 
   let status = $state('');
@@ -61,6 +67,8 @@
     const offSolved = onSolved(() => {
       showEmojiRain = false;
       queueMicrotask(() => (showEmojiRain = true));
+      const solveCount = recordSolve();
+      supportPrompt = isPrime(solveCount) ? nextSupportPrompt() : null;
     });
     const onKey = (event: KeyboardEvent) => {
       closeMenuOnEscape(event);
@@ -156,6 +164,7 @@
   function handleSizeClick(s: number): void {
     status = t('play_status_switching');
     switchToSize(s);
+    supportPrompt = null;
     status = '';
   }
 
@@ -164,6 +173,7 @@
     status = t('play_status_generating');
     queueMicrotask(() => {
       newPuzzle(playState.puzzleData!.row_targets.length);
+      supportPrompt = null;
       status = '';
     });
   }
@@ -183,6 +193,7 @@
     queueMicrotask(() => {
       try {
         newPuzzleWithDifficulty(size, d);
+        supportPrompt = null;
       } finally {
         status = '';
       }
@@ -464,6 +475,12 @@
       onPlaceValue={(v) => applyUserValue(v)}
       onErase={() => applyUserNote(null)}
     />
+  {/if}
+
+  {#if supportPrompt}
+    {#key supportPrompt}
+      <SupportCard prompt={supportPrompt} onDismiss={() => (supportPrompt = null)} />
+    {/key}
   {/if}
 </div>
 

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -206,6 +206,15 @@ export const de: Messages = {
   share_title: 'Doplo-Puzzle',
   share_text: 'Probier dieses Doplo-Puzzle:',
 
+  // Support CTA (post-solve)
+  support_copy_1: 'Macht dir rublock Spaß? Unterstütze die Entwicklung.',
+  support_copy_2: 'rublock ist kostenlos und werbefrei — hilf mit, dass das so bleibt.',
+  support_copy_3: 'Magst du diese Puzzles? Trag etwas bei, damit es weitergeht.',
+  support_copy_4: 'Von einer einzelnen Person entwickelt. Eine kleine Spende hilft sehr.',
+  support_copy_5: 'Wenn rublock deinen Tag verschönert hat, denk ans Unterstützen.',
+  support_button: 'Auf {platform} unterstützen',
+  support_dismiss_aria: 'Schließen',
+
   // Wasm errors
   err_row_targets_length: 'Anzahl Zeilen-Zielwerte passt nicht zur Puzzle-Größe.',
   err_col_targets_length: 'Anzahl Spalten-Zielwerte passt nicht zur Puzzle-Größe.',

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -14,6 +14,7 @@
 //   cls_*       Classification chip labels
 //   toast_*     Transient toasts
 //   share_*     Web Share / clipboard
+//   support_*   Post-solve "support the project" CTA (copy + button + dismiss)
 //   aria_*      Aria-labels for buttons that have only an icon
 //   err_*       Errors, including translated wasm errors
 //
@@ -223,6 +224,16 @@ export const en = {
   // Web Share API
   share_title: 'Doplo puzzle',
   share_text: 'Try this Doplo puzzle:',
+
+  // Support CTA (post-solve) — five rotating calls-to-action. {platform} is a
+  // brand name (Liberapay / Ko-fi) and stays untranslated.
+  support_copy_1: 'Enjoying rublock? Support its development.',
+  support_copy_2: 'rublock is free and ad-free — help keep it that way.',
+  support_copy_3: 'Like these puzzles? Chip in to keep them coming.',
+  support_copy_4: 'Made by one developer. A small gift goes a long way.',
+  support_copy_5: 'If rublock brightened your day, consider supporting it.',
+  support_button: 'Support on {platform}',
+  support_dismiss_aria: 'Dismiss',
 
   // Wasm errors (mapped from raw Rust strings in web/src/wasm/api.ts)
   err_row_targets_length: 'Row targets length does not match the puzzle size.',

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -208,6 +208,15 @@ export const fr: Messages = {
   share_title: 'Puzzle Doplo',
   share_text: 'Essaie ce puzzle Doplo :',
 
+  // Support CTA (post-solve)
+  support_copy_1: 'rublock te plaît ? Soutiens son développement.',
+  support_copy_2: 'rublock est gratuit et sans publicité — aide à le garder ainsi.',
+  support_copy_3: "Tu aimes ces puzzles ? Contribue pour qu'ils continuent.",
+  support_copy_4: 'Créé par une seule personne. Un petit geste fait beaucoup.',
+  support_copy_5: 'Si rublock a égayé ta journée, pense à le soutenir.',
+  support_button: 'Soutenir sur {platform}',
+  support_dismiss_aria: 'Fermer',
+
   // Wasm errors
   err_row_targets_length: 'Le nombre de cibles de ligne ne correspond pas à la taille du puzzle.',
   err_col_targets_length: 'Le nombre de cibles de colonne ne correspond pas à la taille du puzzle.',

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -207,6 +207,15 @@ export const pt: Messages = {
   share_title: 'Puzzle Doplo',
   share_text: 'Experimenta este puzzle Doplo:',
 
+  // Support CTA (post-solve)
+  support_copy_1: 'Gostas do rublock? Apoia o seu desenvolvimento.',
+  support_copy_2: 'O rublock é gratuito e sem anúncios — ajuda a mantê-lo assim.',
+  support_copy_3: 'Gostas destes puzzles? Contribui para que continuem.',
+  support_copy_4: 'Feito por uma só pessoa. Um pequeno gesto ajuda muito.',
+  support_copy_5: 'Se o rublock alegrou o teu dia, considera apoiá-lo.',
+  support_button: 'Apoiar no {platform}',
+  support_dismiss_aria: 'Fechar',
+
   // Wasm errors
   err_row_targets_length: 'O número de alvos de linha não corresponde ao tamanho do puzzle.',
   err_col_targets_length: 'O número de alvos de coluna não corresponde ao tamanho do puzzle.',

--- a/web/src/state/storage.ts
+++ b/web/src/state/storage.ts
@@ -14,6 +14,8 @@
 export const KEY_PLAY_STATE = 'rublock-play-state';
 export const KEY_LOCALE = 'rublock-locale';
 export const KEY_HINT_DISMISSED = 'rublock-hint-dismissed';
+export const KEY_SOLVE_COUNT = 'rublock-solve-count';
+export const KEY_SUPPORT_SHOWN = 'rublock-support-shown';
 
 let writesDisabled = false;
 let warnedOnce = false;
@@ -70,4 +72,35 @@ export function readHintDismissed(): boolean {
 export function writeHintDismissed(value: boolean): void {
   if (value) safeWrite(KEY_HINT_DISMISSED, '1');
   else safeRemove(KEY_HINT_DISMISSED);
+}
+
+// ---------- Post-solve support CTA counters ----------
+//
+// Two small non-negative integers. `solve-count` is the lifetime number of
+// puzzles solved and drives the prime-number gate that decides when to show the
+// support card; `support-shown` is how many times the card has been shown and
+// drives the platform/copy rotation. Both persist so the cadence and the
+// rotation continue across sessions instead of resetting each visit.
+
+function readCount(key: string): number {
+  const raw = safeRead(key);
+  if (raw === null) return 0;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+export function readSolveCount(): number {
+  return readCount(KEY_SOLVE_COUNT);
+}
+
+export function writeSolveCount(value: number): void {
+  safeWrite(KEY_SOLVE_COUNT, String(value));
+}
+
+export function readSupportShown(): number {
+  return readCount(KEY_SUPPORT_SHOWN);
+}
+
+export function writeSupportShown(value: number): void {
+  safeWrite(KEY_SUPPORT_SHOWN, String(value));
 }

--- a/web/src/state/support.ts
+++ b/web/src/state/support.ts
@@ -1,0 +1,102 @@
+// Post-solve "support the project" call-to-action.
+//
+// rublock is free and ad-free. Occasionally, after a solved puzzle, we show a
+// small card linking to a donation platform. This module owns the policy:
+//   * WHEN to show it — only when the lifetime solve count is prime, so the ask
+//     is frequent at first (2nd, 3rd, 5th, 7th… solve) and then naturally rare.
+//   * WHICH platform + copy to show — a persisted rotation so that, over time,
+//     every (platform, copy) pairing is shown roughly equally. That's the data
+//     we need to learn which combination converts best.
+//   * Reporting impressions and clicks to GoatCounter (production only, via
+//     `trackEvent`).
+//
+// The component (`SupportCard.svelte`) is intentionally dumb: it renders a
+// prompt produced here and reports the events. All counters go through the
+// centralised `storage.ts` helpers.
+
+import type { MessageKey } from '../i18n/en';
+import { trackEvent } from '../analytics';
+import { readSolveCount, writeSolveCount, readSupportShown, writeSupportShown } from './storage';
+
+export interface SupportPlatform {
+  /** Stable id, used in GoatCounter event paths and in tests. */
+  id: 'liberapay' | 'kofi';
+  /** Brand name shown to the player (a proper noun — not translated). */
+  label: string;
+  /** Destination URL. */
+  url: string;
+}
+
+// NOTE(owner): the Liberapay handle `Sjlver` is confirmed live. The Ko-fi
+// handle is a best guess — confirm or replace it once the Ko-fi account exists.
+export const SUPPORT_PLATFORMS: readonly SupportPlatform[] = [
+  { id: 'liberapay', label: 'Liberapay', url: 'https://liberapay.com/Sjlver/' },
+  { id: 'kofi', label: 'Ko-fi', url: 'https://ko-fi.com/sjlver' },
+];
+
+// Five rotating calls-to-action. The keys resolve through the i18n catalog, so
+// the copy is translated; rotation picks an index and the component renders
+// `t(key)`. Keep this in sync with the `support_copy_*` keys in `i18n/en.ts`.
+export const SUPPORT_COPY_KEYS: readonly MessageKey[] = [
+  'support_copy_1',
+  'support_copy_2',
+  'support_copy_3',
+  'support_copy_4',
+  'support_copy_5',
+];
+
+export interface SupportPrompt {
+  platform: SupportPlatform;
+  copyKey: MessageKey;
+  /** 0-based copy index; appears in the GoatCounter event path. */
+  copyIndex: number;
+}
+
+/** Trial-division primality test. `n < 2` is not prime. */
+export function isPrime(n: number): boolean {
+  if (!Number.isInteger(n) || n < 2) return false;
+  if (n % 2 === 0) return n === 2;
+  if (n % 3 === 0) return n === 3;
+  for (let i = 5; i * i <= n; i += 6) {
+    if (n % i === 0 || n % (i + 2) === 0) return false;
+  }
+  return true;
+}
+
+/**
+ * Record one solved puzzle and return the new lifetime solve count. The
+ * support card is shown only when this count is prime.
+ */
+export function recordSolve(): number {
+  const next = readSolveCount() + 1;
+  writeSolveCount(next);
+  return next;
+}
+
+/**
+ * Pick the next CTA and advance the rotation. Platform cycles every show and
+ * copy cycles every five; because 2 and 5 are coprime, all ten pairings appear
+ * within every ten shows. The "shown" counter is persisted so the rotation
+ * continues across sessions rather than restarting at the same pairing.
+ */
+export function nextSupportPrompt(): SupportPrompt {
+  const shown = readSupportShown();
+  writeSupportShown(shown + 1);
+  const platform = SUPPORT_PLATFORMS[shown % SUPPORT_PLATFORMS.length];
+  const copyIndex = shown % SUPPORT_COPY_KEYS.length;
+  return { platform, copyKey: SUPPORT_COPY_KEYS[copyIndex], copyIndex };
+}
+
+function eventPath(action: 'impression' | 'click', p: SupportPrompt): string {
+  // e.g. "rublock/support/impression/liberapay/0" — slashes group the dimensions
+  // so the GoatCounter dashboard can be filtered by action, platform, or copy.
+  return `rublock/support/${action}/${p.platform.id}/${p.copyIndex}`;
+}
+
+export function trackSupportImpression(p: SupportPrompt): void {
+  trackEvent(eventPath('impression', p));
+}
+
+export function trackSupportClick(p: SupportPrompt): void {
+  trackEvent(eventPath('click', p));
+}

--- a/web/tests/support-card.spec.ts
+++ b/web/tests/support-card.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// The post-solve "support the project" card shows only when the lifetime solve
+// count is prime (see web/src/state/support.ts). These tests drive a real solve
+// and seed the persisted count so the next solve lands on a chosen number.
+//
+// The card itself renders in every build mode (it's just links). The
+// GoatCounter impression/click events fire only in `--mode production`, so they
+// stay silent under Playwright's `--mode test` build and aren't asserted here.
+
+// A known-solvable 6×6 puzzle and its hand-checked solution (same fixture the
+// retired EthicalAds-slot test used). 'black' = a black square; the rest are
+// placed digits.
+const PUZZLE = '7047430a4100';
+const SOLUTION: ReadonlyArray<ReadonlyArray<string>> = [
+  ['3', 'black', '1', '2', '4', 'black'],
+  ['4', '1', '2', '3', 'black', 'black'],
+  ['1', '2', 'black', '4', 'black', '3'],
+  ['black', '3', '4', 'black', '2', '1'],
+  ['black', '4', 'black', '1', '3', '2'],
+  ['2', 'black', '3', 'black', '1', '4'],
+];
+
+const KEY_SOLVE_COUNT = 'rublock-solve-count';
+
+async function waitForReady(page: Page) {
+  await expect(page.locator('.app-shell table.puzzle')).toBeVisible();
+}
+
+// Seed the lifetime solve count so the *next* solve lands on a chosen value.
+// Runs before the app boots on the upcoming navigation.
+async function seedSolveCount(page: Page, value: number) {
+  await page.addInitScript(({ key, value }) => localStorage.setItem(key, String(value)), {
+    key: KEY_SOLVE_COUNT,
+    value,
+  });
+}
+
+async function solveCurrentPuzzle(page: Page) {
+  const rows = page.locator('.app-shell table.puzzle tbody tr');
+  for (let r = 0; r < 6; r++) {
+    for (let c = 0; c < 6; c++) {
+      await rows.nth(r).locator('td').nth(c).click();
+      await page.keyboard.press(SOLUTION[r][c] === 'black' ? 'b' : SOLUTION[r][c]);
+    }
+  }
+  // The solve toast confirms the solved-event fired and the latch updated.
+  await expect(page.locator('[role="status"]')).toContainText('Puzzle solved!');
+}
+
+test('the support card appears on a prime-numbered solve', async ({ page }) => {
+  await seedSolveCount(page, 1); // next solve → count 2 (prime)
+  await page.goto(`/?p=${PUZZLE}`);
+  await waitForReady(page);
+  await solveCurrentPuzzle(page);
+
+  const card = page.locator('[data-support-card]');
+  await expect(card).toBeVisible();
+  // The first card ever shown is deterministic: rotation index 0 → Liberapay.
+  await expect(card).toHaveAttribute('data-support-platform', 'liberapay');
+  // The CTA links to one of the two configured donation platforms.
+  await expect(card.locator('a[href]')).toHaveAttribute(
+    'href',
+    /^https:\/\/(liberapay\.com|ko-fi\.com)\//
+  );
+});
+
+test('no support card on a non-prime solve', async ({ page }) => {
+  await seedSolveCount(page, 3); // next solve → count 4 (composite)
+  await page.goto(`/?p=${PUZZLE}`);
+  await waitForReady(page);
+  await solveCurrentPuzzle(page);
+
+  await expect(page.locator('[data-support-card]')).toHaveCount(0);
+});
+
+test('the support card can be dismissed', async ({ page }) => {
+  await seedSolveCount(page, 1);
+  await page.goto(`/?p=${PUZZLE}`);
+  await waitForReady(page);
+  await solveCurrentPuzzle(page);
+
+  const card = page.locator('[data-support-card]');
+  await expect(card).toBeVisible();
+  await card.locator('.support-dismiss').click();
+  await expect(card).toHaveCount(0);
+});


### PR DESCRIPTION
## What

Replaces the dormant EthicalAds slot from #50 with a privacy-respecting **"support the project" card** shown after some solved puzzles. The card links to Liberapay or Ko-fi — it's a plain `<a>`, no ad scripts, no trackers.

This is the agreed disposition of #50: EthicalAds turned out to be structurally wrong for rublock (a 50k-pageview floor **and** a placement policy that forbids a post-solve interstitial), so the slot is repurposed rather than wired to an ad network. #50 is branched off an older `main` and will be closed in favour of this PR, which is branched off current `main`.

## How it behaves

- **When:** only when your lifetime solve count is **prime** (2nd, 3rd, 5th, 7th, 11th… puzzle). Frequent at first, then naturally rare as prime gaps widen — so it never nags a regular player.
- **What:** a small dismissible card below the board, with one of **5 rotating copies** linking to one of **2 platforms**. Platform and copy rotate off a persisted counter, so over every 10 shows all 10 (platform × copy) pairings appear about equally.
- **Measurement:** fires GoatCounter events `rublock/support/impression/<platform>/<copyIndex>` on show and `rublock/support/click/<platform>/<copyIndex>` on click — **production only**, via the existing `trackEvent` helper — so the best-converting combination can be found later. No new analytics dependency.
- **i18n:** copy, button, and dismiss label are translated in de / en / fr / pt.

## Files

| File | Change |
|---|---|
| `web/src/state/storage.ts` | two `localStorage` counters (solve-count, support-shown) |
| `web/src/state/support.ts` | prime gate, platform/copy rotation, GoatCounter event helpers |
| `web/src/components/SupportCard.svelte` | the card (impression on mount, click event) |
| `web/src/components/tabs/PlayTab.svelte` | prime-gated latch in `onSolved`; reset on new puzzle / size switch |
| `web/src/i18n/{en,de,fr,pt}.ts` | `support_copy_1..5`, `support_button`, `support_dismiss_aria` |
| `PRIVACY.md` (new), `README.md` | describe the card; no EthicalAds language |
| `web/tests/support-card.spec.ts` | shown on a prime solve, hidden on a composite solve, dismissable |

## Testing

- `npm run check` — clean (0 errors).
- `mise run test-web` — **51/51** Playwright tests pass (3 new + no regressions).
- Manual: solved a puzzle in the preview build and screenshotted both variants (EN/Liberapay and DE/Ko-fi) to confirm layout, rotation, and i18n.

## ⚠️ Please confirm before merge / deploy

1. **Ko-fi handle.** I used `https://ko-fi.com/sjlver` as a placeholder. Liberapay `Sjlver` is confirmed live, but the Ko-fi handle couldn't be verified — create the account and fix the URL in `web/src/state/support.ts` (`SUPPORT_PLATFORMS`) if it differs. Both URLs live in that one array.
2. **Copy.** The 5 CTA texts and their de/fr/pt translations live in the i18n catalogs — tweak to taste.
3. **Placement.** The card sits inline below the number pad (the same slot #50 used). If you'd rather it be tied more tightly to the celebration (e.g. a centered overlay with the emoji rain), say so and I'll move it.

It's link-only and on by default, so merging ships it on the next Pages build — no extra deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)